### PR TITLE
Define the manifest schema

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -21,6 +21,12 @@ export default defineConfig({
 						{ label: "Vision", slug: "vision" },
 					],
 				},
+				{
+					label: "Specification",
+					items: [
+						{ label: "Manifest", slug: "spec/manifest" },
+					],
+				},
 			],
 			customCss: ["./src/styles/custom.css"],
 			editLink: {

--- a/docs/src/content/docs/spec/manifest.md
+++ b/docs/src/content/docs/spec/manifest.md
@@ -1,0 +1,216 @@
+---
+title: Manifest Specification
+description: The xript manifest format — how applications declare their scripting API.
+---
+
+The xript manifest is the single source of truth for an application's scripting API. It declares what functionality is exposed to scripts, how it is organized, what capabilities gate access, and what types are involved. From the manifest, everything else is derived: documentation, TypeScript definitions, validation, and playground environments.
+
+## Overview
+
+A manifest is a JSON file conforming to the [manifest JSON Schema](https://github.com/nekoyoubi/xript/blob/main/spec/manifest.schema.json). At minimum, a manifest declares a spec version and a name:
+
+```json
+{
+  "xript": "0.1",
+  "name": "my-app"
+}
+```
+
+From there, complexity is layered on only as needed. Every field beyond `xript` and `name` is optional, and each additional section enables more functionality.
+
+## Top-Level Fields
+
+### `xript` (required)
+
+The specification version this manifest conforms to. This is not the application's version — it's the version of the xript spec the manifest was written against.
+
+Format: `major.minor` (e.g., `"0.1"`).
+
+### `name` (required)
+
+A machine-readable identifier for the application. Used in generated package names, documentation URLs, and tooling output.
+
+Constraints: lowercase letters, numbers, and hyphens. Must start with a letter. Maximum 64 characters.
+
+### `version`
+
+The version of the application's scripting API, following semver. Tracks how the exposed bindings evolve over time.
+
+### `title`
+
+A human-readable display name. Used in documentation headers and UI.
+
+### `description`
+
+A brief description aimed at modders. Used in documentation landing pages and registry listings.
+
+## Bindings
+
+Bindings define the functions and namespaces that scripts can call.
+
+### Function Bindings
+
+A function binding declares a callable function:
+
+```json
+{
+  "bindings": {
+    "getHealth": {
+      "description": "Returns the player's current health points.",
+      "returns": "number"
+    }
+  }
+}
+```
+
+Every function binding requires a `description`. Optional fields include `params`, `returns`, `async`, `capability`, `examples`, and `deprecated`.
+
+### Namespace Bindings
+
+Namespaces group related functions using the `members` field:
+
+```json
+{
+  "bindings": {
+    "player": {
+      "description": "Functions related to the player character.",
+      "members": {
+        "getHealth": {
+          "description": "Returns the player's current health points.",
+          "returns": "number"
+        },
+        "setHealth": {
+          "description": "Sets the player's health points.",
+          "params": [
+            { "name": "value", "type": "number", "description": "The new health value." }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+Namespaces can nest, but deep nesting is discouraged — two levels is usually plenty.
+
+## Capabilities
+
+Capabilities implement the default-deny security model. Every capability is a named permission that must be explicitly granted before scripts can use the functionality it protects.
+
+```json
+{
+  "capabilities": {
+    "filesystem": {
+      "description": "Read and write files in the mod's data directory.",
+      "risk": "medium"
+    }
+  }
+}
+```
+
+Functions reference capabilities via the `capability` field. Functions without a `capability` are always available.
+
+The `risk` field (`low`, `medium`, `high`) is advisory and helps users make informed decisions about granting capabilities.
+
+## Types
+
+Custom types describe complex data structures used in bindings.
+
+### Object Types
+
+```json
+{
+  "types": {
+    "Position": {
+      "description": "A 2D position in world coordinates.",
+      "fields": {
+        "x": { "type": "number", "description": "Horizontal position." },
+        "y": { "type": "number", "description": "Vertical position." }
+      }
+    }
+  }
+}
+```
+
+### Enum Types
+
+```json
+{
+  "types": {
+    "Direction": {
+      "description": "A cardinal direction.",
+      "values": ["north", "south", "east", "west"]
+    }
+  }
+}
+```
+
+### Type References
+
+Anywhere a type is expected, you can use:
+
+- **Primitives**: `"string"`, `"number"`, `"boolean"`, `"void"`, `"null"`
+- **Custom types**: `"Position"`, `"Direction"`
+- **Array shorthand**: `"string[]"`, `"Position[]"`
+- **Complex expressions**: `{ "array": "Position" }`, `{ "union": ["string", "number"] }`, `{ "map": "number" }`, `{ "optional": "string" }`
+
+## Execution Limits
+
+Default bounds for script execution:
+
+```json
+{
+  "limits": {
+    "timeout_ms": 5000,
+    "memory_mb": 64,
+    "max_stack_depth": 256
+  }
+}
+```
+
+These are defaults that runtimes enforce unless the host application overrides them.
+
+## Adoption Tiers
+
+The manifest supports three adoption tiers through progressive complexity.
+
+### Tier 1: Expressions Only
+
+```json
+{
+  "xript": "0.1",
+  "name": "calculator"
+}
+```
+
+Safe eval replacement. No bindings, no capabilities.
+
+### Tier 2: Simple Bindings
+
+```json
+{
+  "xript": "0.1",
+  "name": "my-game",
+  "version": "1.0.0",
+  "bindings": {
+    "getPlayerName": {
+      "description": "Returns the current player's display name.",
+      "returns": "string"
+    },
+    "getHealth": {
+      "description": "Returns the player's current health (0-100).",
+      "returns": "number"
+    }
+  }
+}
+```
+
+A few functions, no capabilities needed.
+
+### Tier 3: Full Scripting
+
+Namespaces, capabilities, custom types, examples, and execution limits. See the [game mod system example](https://github.com/nekoyoubi/xript/blob/main/examples/game-mod-system.json) for a complete tier 3 manifest.
+
+## Schema
+
+The full JSON Schema is available at [`spec/manifest.schema.json`](https://github.com/nekoyoubi/xript/blob/main/spec/manifest.schema.json).

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,8 +2,11 @@
 
 Example manifests and integrations demonstrating xript in action.
 
+## Manifests
+
+- [game-mod-system.json](./game-mod-system.json) — a full tier 3 manifest for a dungeon crawler game, demonstrating namespaces, capabilities, custom types, examples, and execution limits
+
 ## Planned Examples
 
-- Simple expression evaluator
-- Game mod system
+- Simple expression evaluator (runnable, with host app)
 - Plugin architecture for a CLI tool

--- a/examples/game-mod-system.json
+++ b/examples/game-mod-system.json
@@ -1,0 +1,165 @@
+{
+	"xript": "0.1",
+	"name": "dungeon-crawler",
+	"version": "1.2.0",
+	"title": "Dungeon Crawler",
+	"description": "A roguelike dungeon crawler. Mods can read game state, modify player stats, create custom items, and react to game events.",
+
+	"bindings": {
+		"log": {
+			"description": "Writes a message to the mod console.",
+			"params": [
+				{ "name": "message", "type": "string", "description": "The message to log." }
+			]
+		},
+		"player": {
+			"description": "Functions for reading and modifying the player character.",
+			"members": {
+				"getName": {
+					"description": "Returns the player's display name.",
+					"returns": "string"
+				},
+				"getHealth": {
+					"description": "Returns the player's current health points.",
+					"returns": "number"
+				},
+				"getMaxHealth": {
+					"description": "Returns the player's maximum health points.",
+					"returns": "number"
+				},
+				"getPosition": {
+					"description": "Returns the player's current position in the dungeon.",
+					"returns": "Position"
+				},
+				"setHealth": {
+					"description": "Sets the player's health to a specific value. Clamped to 0..maxHealth.",
+					"params": [
+						{ "name": "value", "type": "number", "description": "The new health value." }
+					],
+					"capability": "modify-player",
+					"examples": [
+						{
+							"title": "Full heal",
+							"code": "const max = player.getMaxHealth();\nplayer.setHealth(max);",
+							"description": "Restores the player to full health."
+						}
+					]
+				},
+				"getInventory": {
+					"description": "Returns all items in the player's inventory.",
+					"returns": { "array": "Item" }
+				},
+				"addItem": {
+					"description": "Adds an item to the player's inventory.",
+					"params": [
+						{ "name": "item", "type": "Item", "description": "The item to add." }
+					],
+					"capability": "modify-player"
+				}
+			}
+		},
+		"world": {
+			"description": "Functions for querying the game world.",
+			"members": {
+				"getCurrentLevel": {
+					"description": "Returns the current dungeon level number (1-indexed).",
+					"returns": "number"
+				},
+				"getEnemies": {
+					"description": "Returns all enemies on the current level.",
+					"returns": { "array": "Enemy" },
+					"async": true
+				},
+				"spawnEnemy": {
+					"description": "Spawns an enemy at the given position.",
+					"params": [
+						{ "name": "type", "type": "EnemyType", "description": "The type of enemy to spawn." },
+						{ "name": "position", "type": "Position", "description": "Where to spawn the enemy." }
+					],
+					"capability": "modify-world"
+				}
+			}
+		},
+		"data": {
+			"description": "Persistent data storage for mods.",
+			"members": {
+				"get": {
+					"description": "Reads a value from the mod's persistent storage.",
+					"params": [
+						{ "name": "key", "type": "string", "description": "The storage key." }
+					],
+					"returns": { "optional": "string" },
+					"capability": "storage",
+					"async": true
+				},
+				"set": {
+					"description": "Writes a value to the mod's persistent storage.",
+					"params": [
+						{ "name": "key", "type": "string", "description": "The storage key." },
+						{ "name": "value", "type": "string", "description": "The value to store." }
+					],
+					"capability": "storage",
+					"async": true
+				}
+			}
+		}
+	},
+
+	"capabilities": {
+		"modify-player": {
+			"description": "Modify the player's stats, inventory, and equipment.",
+			"risk": "medium"
+		},
+		"modify-world": {
+			"description": "Spawn or remove entities in the game world.",
+			"risk": "high"
+		},
+		"storage": {
+			"description": "Read and write persistent data for this mod.",
+			"risk": "low"
+		}
+	},
+
+	"types": {
+		"Position": {
+			"description": "A 2D position in dungeon coordinates.",
+			"fields": {
+				"x": { "type": "number", "description": "Horizontal position (column)." },
+				"y": { "type": "number", "description": "Vertical position (row)." }
+			}
+		},
+		"Item": {
+			"description": "An item that can exist in the player's inventory.",
+			"fields": {
+				"id": { "type": "string", "description": "Unique item identifier." },
+				"name": { "type": "string", "description": "Display name." },
+				"type": { "type": "ItemType", "description": "The category of item." },
+				"damage": { "type": "number", "description": "Damage value for weapons.", "optional": true },
+				"healing": { "type": "number", "description": "Healing value for consumables.", "optional": true }
+			}
+		},
+		"Enemy": {
+			"description": "An enemy in the dungeon.",
+			"fields": {
+				"id": { "type": "string", "description": "Unique enemy instance identifier." },
+				"type": { "type": "EnemyType", "description": "The enemy type." },
+				"health": { "type": "number", "description": "Current health points." },
+				"position": { "type": "Position", "description": "Current position." }
+			}
+		},
+		"ItemType": {
+			"description": "Categories of items.",
+			"values": ["weapon", "armor", "consumable", "key", "quest"]
+		},
+		"EnemyType": {
+			"description": "Types of enemies that can appear in the dungeon.",
+			"values": ["skeleton", "goblin", "slime", "dragon", "mimic"]
+		}
+	},
+
+	"limits": {
+		"timeout_ms": 1000,
+		"memory_mb": 32,
+		"max_stack_depth": 128
+	}
+}

--- a/spec/README.md
+++ b/spec/README.md
@@ -5,10 +5,11 @@ The xript specification defines how applications expose functionality to scripts
 ## Contents
 
 - [vision.md](./vision.md) — the guiding vision for xript
+- [manifest.md](./manifest.md) — the manifest format specification
+- [manifest.schema.json](./manifest.schema.json) — the manifest JSON Schema
 
 ## Planned
 
-- Manifest schema (JSON Schema)
 - Capability model
 - Binding conventions
 - Security guarantees

--- a/spec/manifest.md
+++ b/spec/manifest.md
@@ -1,0 +1,256 @@
+# xript Manifest Specification
+
+The xript manifest is the single source of truth for an application's scripting API. It declares what functionality is exposed to scripts, how it is organized, what capabilities gate access, and what types are involved. From the manifest, everything else is derived: documentation, TypeScript definitions, validation, and playground environments.
+
+This document explains the structure of the manifest, the rationale behind key decisions, and how the manifest supports xript's three adoption tiers.
+
+## Overview
+
+A manifest is a JSON file conforming to the [manifest JSON Schema](./manifest.schema.json). At minimum, a manifest declares a spec version and a name:
+
+```json
+{
+  "xript": "0.1",
+  "name": "my-app"
+}
+```
+
+From there, complexity is layered on only as needed. The schema is designed so that every field beyond `xript` and `name` is optional, and each additional section enables more functionality.
+
+## Top-Level Fields
+
+### `xript` (required)
+
+The specification version this manifest conforms to. This is not the application's version — it's the version of the xript spec the manifest was written against. Runtimes use this to determine which features and validation rules apply.
+
+Format: `major.minor` (e.g., `"0.1"`). Patch versions are intentionally excluded — the spec level doesn't change for non-breaking fixes.
+
+### `name` (required)
+
+A machine-readable identifier for the application. Used in generated package names (`@xript/<name>-types`), documentation URLs, and tooling output.
+
+Constraints: lowercase letters, numbers, and hyphens. Must start with a letter. Maximum 64 characters. This mirrors npm package naming conventions because the generated types will live in that ecosystem.
+
+### `version`
+
+The version of the application's scripting API, following semver. This is distinct from `xript` — it tracks how the application's exposed bindings evolve over time.
+
+When a binding is added, the minor version increments. When a binding's signature changes in a breaking way, the major version increments. This versioning drives compatibility checks and generated type package versioning.
+
+### `title`
+
+A human-readable display name. While `name` is `"skyrim-modkit"`, `title` might be `"Skyrim Mod Toolkit"`. Used in documentation headers and UI.
+
+### `description`
+
+A brief description aimed at modders. Tells them what the application does and what they can extend. Used in documentation landing pages and registry listings.
+
+## Bindings
+
+Bindings are the core of the manifest. They define the functions and namespaces that scripts can call.
+
+### Function Bindings
+
+A function binding declares a callable function:
+
+```json
+{
+  "bindings": {
+    "getHealth": {
+      "description": "Returns the player's current health points.",
+      "returns": "number"
+    }
+  }
+}
+```
+
+Every function binding requires a `description`. This is not optional because if a modder can't understand what a function does, it may as well not exist. The description appears in generated docs, TypeScript JSDoc comments, and editor tooltips.
+
+Optional fields on function bindings:
+
+- **`params`** — an ordered array of parameters, each with a `name`, `type`, and optional `description` and `default`
+- **`returns`** — the return type (omit for void functions)
+- **`async`** — whether the function returns a promise (defaults to `false`)
+- **`capability`** — the capability required to call this function
+- **`examples`** — usage examples for documentation
+- **`deprecated`** — marks the function as deprecated with a migration message
+
+### Namespace Bindings
+
+Namespaces group related functions. They create the `namespace.function()` calling convention:
+
+```json
+{
+  "bindings": {
+    "player": {
+      "description": "Functions related to the player character.",
+      "members": {
+        "getHealth": {
+          "description": "Returns the player's current health points.",
+          "returns": "number"
+        },
+        "setHealth": {
+          "description": "Sets the player's health points.",
+          "params": [
+            { "name": "value", "type": "number", "description": "The new health value." }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+Namespaces can nest arbitrarily (`game.world.weather.setRain()`), but deep nesting is discouraged — two levels is usually plenty.
+
+A binding is distinguished as a namespace by the presence of `members`. A binding with both `members` and `params` is invalid.
+
+### Why Bindings Are a Flat Object, Not Nested by Default
+
+Bindings are declared as a flat key-value map at the top level (`"getHealth": {...}`) rather than being implicitly grouped. Namespaces exist as an explicit opt-in via `members`. This keeps the simple case simple (one function = one key) while allowing organization when needed.
+
+## Capabilities
+
+Capabilities implement the default-deny security model. Every capability is a named permission that must be explicitly granted before scripts can use the functionality it protects.
+
+```json
+{
+  "capabilities": {
+    "filesystem": {
+      "description": "Read and write files in the mod's data directory.",
+      "risk": "medium"
+    },
+    "network": {
+      "description": "Make HTTP requests to allowed domains.",
+      "risk": "high"
+    }
+  }
+}
+```
+
+Capabilities are referenced by name in function bindings via the `capability` field. A function with `"capability": "filesystem"` is only callable if the script has been granted the `filesystem` capability.
+
+The `risk` field is advisory — it helps users make informed decisions about what to grant. It does not affect runtime behavior. Runtimes may use it to display warnings or require additional confirmation for `high` risk capabilities.
+
+Functions without a `capability` field are always available to any script. This is intentional: the common case is that most bindings are safe read-only operations that don't need gating.
+
+## Types
+
+Custom types let the manifest describe complex data structures used in bindings.
+
+### Object Types
+
+```json
+{
+  "types": {
+    "Position": {
+      "description": "A 2D position in world coordinates.",
+      "fields": {
+        "x": { "type": "number", "description": "Horizontal position." },
+        "y": { "type": "number", "description": "Vertical position." }
+      }
+    }
+  }
+}
+```
+
+### Enum Types
+
+```json
+{
+  "types": {
+    "Direction": {
+      "description": "A cardinal direction.",
+      "values": ["north", "south", "east", "west"]
+    }
+  }
+}
+```
+
+### Type References
+
+Anywhere a type is expected, you can use:
+
+- **Primitives**: `"string"`, `"number"`, `"boolean"`, `"void"`, `"null"`
+- **Custom types**: `"Position"`, `"Direction"` (references to the `types` section)
+- **Array shorthand**: `"string[]"`, `"Position[]"`
+- **Complex expressions**: `{ "array": "Position" }`, `{ "union": ["string", "number"] }`, `{ "map": "number" }`, `{ "optional": "string" }`
+
+The shorthand `"string[]"` is equivalent to `{ "array": "string" }`. Both are valid. The shorthand exists because array types are common and the verbose form is noisy for simple cases.
+
+## Execution Limits
+
+The `limits` section sets default bounds for script execution:
+
+```json
+{
+  "limits": {
+    "timeout_ms": 5000,
+    "memory_mb": 64,
+    "max_stack_depth": 256
+  }
+}
+```
+
+These are defaults that runtimes enforce unless the host application overrides them at runtime. They exist in the manifest so that the application author can declare sensible defaults for their use case — a game mod system might allow 100ms per frame tick, while a data processing tool might allow 30 seconds.
+
+## Adoption Tiers
+
+The manifest supports xript's three adoption tiers through progressive complexity.
+
+### Tier 1: Expressions Only
+
+The simplest manifest. No bindings, no capabilities. The application uses xript purely as a safe eval replacement for user-provided expressions.
+
+```json
+{
+  "xript": "0.1",
+  "name": "calculator"
+}
+```
+
+The runtime provides only the JavaScript language itself — no host bindings. This is useful for formula fields, template expressions, and user-defined calculations.
+
+### Tier 2: Simple Bindings
+
+The application exposes a few functions. No capabilities needed because everything exposed is inherently safe.
+
+```json
+{
+  "xript": "0.1",
+  "name": "my-game",
+  "version": "1.0.0",
+  "title": "My Game",
+  "bindings": {
+    "getPlayerName": {
+      "description": "Returns the current player's display name.",
+      "returns": "string"
+    },
+    "getHealth": {
+      "description": "Returns the player's current health (0-100).",
+      "returns": "number"
+    },
+    "log": {
+      "description": "Logs a message to the mod console.",
+      "params": [
+        { "name": "message", "type": "string" }
+      ]
+    }
+  }
+}
+```
+
+### Tier 3: Full Scripting with Capabilities
+
+The complete model. Namespaces organize a rich API. Capabilities gate sensitive operations. Custom types describe complex data. Examples document usage.
+
+See [examples/game-mod-system.json](../examples/game-mod-system.json) for a full tier 3 manifest.
+
+## Schema Evolution
+
+The manifest schema will evolve as xript matures. The `xript` field enables runtime compatibility:
+
+- **0.x** versions may introduce breaking changes between minors
+- **1.0** and beyond will follow semver: minors add, majors break
+
+Runtimes should validate the `xript` field first and reject manifests with unsupported spec versions with a clear error message.

--- a/spec/manifest.schema.json
+++ b/spec/manifest.schema.json
@@ -1,0 +1,306 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://xript.dev/schema/manifest/v0.1.json",
+	"title": "xript Manifest",
+	"description": "Declarative manifest for xript-enabled applications. Defines the API surface, capabilities, and documentation for modders.",
+	"type": "object",
+	"required": ["xript", "name"],
+	"properties": {
+		"xript": {
+			"description": "The xript specification version this manifest conforms to.",
+			"type": "string",
+			"pattern": "^\\d+\\.\\d+$",
+			"examples": ["0.1"]
+		},
+		"name": {
+			"description": "Machine-readable identifier for this application. Used in generated package names and documentation URLs.",
+			"type": "string",
+			"pattern": "^[a-z][a-z0-9-]*$",
+			"minLength": 1,
+			"maxLength": 64
+		},
+		"version": {
+			"description": "The version of this application's scripting API. Follows semver.",
+			"type": "string",
+			"pattern": "^\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.]+)?$",
+			"examples": ["1.0.0", "0.3.0-beta.1"]
+		},
+		"title": {
+			"description": "Human-readable display name for the application.",
+			"type": "string",
+			"maxLength": 128
+		},
+		"description": {
+			"description": "A brief description of what this application does and what modders can extend.",
+			"type": "string",
+			"maxLength": 1024
+		},
+		"bindings": {
+			"description": "The functions and namespaces exposed to scripts. This is the API surface.",
+			"type": "object",
+			"additionalProperties": {
+				"$ref": "#/$defs/binding"
+			}
+		},
+		"capabilities": {
+			"description": "Named capabilities that scripts can request. Each capability gates access to a set of bindings or behaviors.",
+			"type": "object",
+			"additionalProperties": {
+				"$ref": "#/$defs/capability"
+			}
+		},
+		"types": {
+			"description": "Custom type definitions referenced by bindings. Enables rich type generation and documentation.",
+			"type": "object",
+			"additionalProperties": {
+				"$ref": "#/$defs/typeDefinition"
+			}
+		},
+		"limits": {
+			"$ref": "#/$defs/executionLimits"
+		}
+	},
+	"additionalProperties": false,
+	"$defs": {
+		"typeRef": {
+			"description": "A reference to a type. Can be a primitive, a custom type name, an array type, or a union.",
+			"oneOf": [
+				{
+					"type": "string",
+					"description": "A primitive type name, custom type reference, or shorthand.",
+					"examples": ["string", "number", "boolean", "void", "null", "Player", "string[]", "number[]"]
+				},
+				{
+					"type": "object",
+					"description": "A complex type expression.",
+					"properties": {
+						"array": {
+							"$ref": "#/$defs/typeRef",
+							"description": "An array of this type."
+						},
+						"union": {
+							"type": "array",
+							"items": { "$ref": "#/$defs/typeRef" },
+							"minItems": 2,
+							"description": "A union of multiple types."
+						},
+						"map": {
+							"$ref": "#/$defs/typeRef",
+							"description": "A string-keyed map with values of this type."
+						},
+						"optional": {
+							"$ref": "#/$defs/typeRef",
+							"description": "An optional (nullable) version of this type."
+						}
+					},
+					"oneOf": [
+						{ "required": ["array"] },
+						{ "required": ["union"] },
+						{ "required": ["map"] },
+						{ "required": ["optional"] }
+					],
+					"additionalProperties": false
+				}
+			]
+		},
+		"parameter": {
+			"description": "A function parameter with a name, type, and optional description.",
+			"type": "object",
+			"required": ["name", "type"],
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": "The parameter name."
+				},
+				"type": {
+					"$ref": "#/$defs/typeRef",
+					"description": "The parameter's type."
+				},
+				"description": {
+					"type": "string",
+					"description": "What this parameter represents."
+				},
+				"default": {
+					"description": "The default value if the parameter is omitted. Implies the parameter is optional."
+				},
+				"required": {
+					"type": "boolean",
+					"description": "Whether this parameter is required. Defaults to true unless a default value is provided.",
+					"default": true
+				}
+			},
+			"additionalProperties": false
+		},
+		"binding": {
+			"description": "A function or namespace exposed to scripts.",
+			"oneOf": [
+				{ "$ref": "#/$defs/functionBinding" },
+				{ "$ref": "#/$defs/namespaceBinding" }
+			]
+		},
+		"functionBinding": {
+			"description": "A callable function exposed to scripts.",
+			"type": "object",
+			"required": ["description"],
+			"properties": {
+				"description": {
+					"type": "string",
+					"description": "What this function does. Shown in generated docs and editor tooltips."
+				},
+				"params": {
+					"type": "array",
+					"items": { "$ref": "#/$defs/parameter" },
+					"description": "The function's parameters, in order."
+				},
+				"returns": {
+					"$ref": "#/$defs/typeRef",
+					"description": "The return type. Omit for void functions."
+				},
+				"async": {
+					"type": "boolean",
+					"description": "Whether this function is asynchronous. Defaults to false.",
+					"default": false
+				},
+				"capability": {
+					"type": "string",
+					"description": "The capability required to call this function. If omitted, the function is always available."
+				},
+				"examples": {
+					"type": "array",
+					"items": { "$ref": "#/$defs/example" },
+					"description": "Usage examples for documentation."
+				},
+				"deprecated": {
+					"type": "string",
+					"description": "If present, this function is deprecated. The value describes the migration path."
+				}
+			},
+			"additionalProperties": false
+		},
+		"namespaceBinding": {
+			"description": "A namespace that groups related functions.",
+			"type": "object",
+			"required": ["description", "members"],
+			"properties": {
+				"description": {
+					"type": "string",
+					"description": "What this namespace represents."
+				},
+				"members": {
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/$defs/binding"
+					},
+					"description": "The functions and sub-namespaces in this namespace."
+				}
+			},
+			"additionalProperties": false
+		},
+		"capability": {
+			"description": "A named capability that gates access to functionality.",
+			"type": "object",
+			"required": ["description"],
+			"properties": {
+				"description": {
+					"type": "string",
+					"description": "What this capability grants access to. Shown to the user when a script requests it."
+				},
+				"risk": {
+					"type": "string",
+					"enum": ["low", "medium", "high"],
+					"description": "Advisory risk level. Helps users make informed decisions about granting capabilities.",
+					"default": "low"
+				}
+			},
+			"additionalProperties": false
+		},
+		"typeDefinition": {
+			"description": "A custom type definition.",
+			"type": "object",
+			"required": ["description"],
+			"properties": {
+				"description": {
+					"type": "string",
+					"description": "What this type represents."
+				},
+				"fields": {
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/$defs/fieldDefinition"
+					},
+					"description": "The fields of this type (for object/struct types)."
+				},
+				"values": {
+					"type": "array",
+					"items": { "type": "string" },
+					"description": "The allowed values (for enum types)."
+				}
+			},
+			"additionalProperties": false
+		},
+		"fieldDefinition": {
+			"description": "A field within a custom type.",
+			"type": "object",
+			"required": ["type"],
+			"properties": {
+				"type": {
+					"$ref": "#/$defs/typeRef"
+				},
+				"description": {
+					"type": "string"
+				},
+				"optional": {
+					"type": "boolean",
+					"description": "Whether this field can be absent. Defaults to false.",
+					"default": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"example": {
+			"description": "A usage example for documentation.",
+			"type": "object",
+			"required": ["code"],
+			"properties": {
+				"title": {
+					"type": "string",
+					"description": "A short title for this example."
+				},
+				"code": {
+					"type": "string",
+					"description": "The JavaScript code demonstrating usage."
+				},
+				"description": {
+					"type": "string",
+					"description": "Explanation of what this example demonstrates."
+				}
+			},
+			"additionalProperties": false
+		},
+		"executionLimits": {
+			"description": "Default execution limits for scripts. Runtimes enforce these limits to prevent denial of service.",
+			"type": "object",
+			"properties": {
+				"timeout_ms": {
+					"type": "integer",
+					"minimum": 1,
+					"description": "Maximum execution time in milliseconds.",
+					"default": 5000
+				},
+				"memory_mb": {
+					"type": "integer",
+					"minimum": 1,
+					"description": "Maximum memory usage in megabytes.",
+					"default": 64
+				},
+				"max_stack_depth": {
+					"type": "integer",
+					"minimum": 1,
+					"description": "Maximum call stack depth.",
+					"default": 256
+				}
+			},
+			"additionalProperties": false
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Designed and wrote the xript manifest JSON Schema (`spec/manifest.schema.json`) covering metadata, bindings, capabilities, types, and execution limits (closes #2)
- Wrote the prose specification (`spec/manifest.md`) with design rationale, code examples, and documentation of the three adoption tiers
- Created a full tier 3 example manifest (`examples/game-mod-system.json`) for a dungeon crawler game, validated against the schema
- Added the manifest spec page to the docs site

## Test plan

- [x] Example manifest validates against the schema via `ajv-cli`
- [x] Docs site builds with the new manifest spec page (4 pages total)
- [ ] Schema covers all five sections: metadata, bindings, capabilities, types, limits
- [ ] Prose spec explains each section with rationale and examples
- [ ] Three adoption tiers are documented with example manifests
- [ ] Sidebar shows "Specification > Manifest" on the docs site