### PR TITLE
complete Spec v0.1 milestone

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -25,6 +25,9 @@ export default defineConfig({
 					label: "Specification",
 					items: [
 						{ label: "Manifest", slug: "spec/manifest" },
+						{ label: "Capabilities", slug: "spec/capabilities" },
+						{ label: "Bindings", slug: "spec/bindings" },
+						{ label: "Security", slug: "spec/security" },
 					],
 				},
 			],

--- a/docs/src/content/docs/spec/bindings.md
+++ b/docs/src/content/docs/spec/bindings.md
@@ -1,0 +1,237 @@
+---
+title: Binding Conventions
+description: Runtime conventions for xript bindings — error handling, versioning, and TypeScript type mapping.
+---
+
+Bindings are the bridge between the host application and modder scripts. The [manifest schema](/spec/manifest) defines how bindings are declared. This document covers the runtime conventions that govern how bindings behave: error handling, versioning, and the mapping from manifest declarations to generated TypeScript types.
+
+## Error Handling
+
+### Host-Side Errors
+
+When a binding function throws an error inside the host application, the runtime must:
+
+1. **Catch the error** before it propagates to the script
+2. **Wrap it** in a `BindingError` with:
+   - The original error message
+   - The binding name (e.g., `"player.setHealth"`)
+   - No stack trace from the host (this would leak implementation details outside the sandbox)
+3. **Throw the `BindingError`** into the script context so the modder can catch and handle it
+
+Example from the modder's perspective:
+
+```javascript
+try {
+  player.setHealth(-1);
+} catch (e) {
+  // e.name === "BindingError"
+  // e.message === "player.setHealth: health value must be non-negative"
+  // e.binding === "player.setHealth"
+  log(e.message);
+}
+```
+
+### Script-Side Error Handling
+
+Modders can wrap binding calls in try/catch. Uncaught errors from bindings terminate the script with the error message logged to the host's mod console.
+
+### Error Types
+
+The runtime provides these error types to scripts:
+
+| Error | When Thrown |
+|-------|------------|
+| `BindingError` | A binding function failed during execution |
+| `CapabilityDeniedError` | A gated function was called without the required capability |
+| `TypeError` | Arguments don't match the binding's declared parameter types |
+
+Runtimes may add additional error types, but these three must be present.
+
+### Type Validation
+
+Runtimes should validate argument types before invoking the host binding. If a binding declares `params: [{ "name": "value", "type": "number" }]` and the modder passes a string, the runtime should throw a `TypeError` without calling the host function. This prevents unexpected values from reaching the host and provides clear feedback to the modder.
+
+Type validation is recommended but not strictly required — some runtimes may defer to the host's own type checking for performance reasons.
+
+## Versioning
+
+### API Versioning Through the Manifest
+
+The manifest's `version` field tracks the scripting API version using semver:
+
+- **Patch** (1.0.x): Bug fixes in binding behavior. No signature changes.
+- **Minor** (1.x.0): New bindings added. Existing bindings unchanged.
+- **Major** (x.0.0): Breaking changes to existing binding signatures or behavior.
+
+### Deprecation
+
+Bindings can be marked deprecated in the manifest:
+
+```json
+{
+  "getHP": {
+    "description": "Returns the player's health.",
+    "returns": "number",
+    "deprecated": "Use player.getHealth() instead."
+  }
+}
+```
+
+Runtimes should:
+- Log a deprecation warning the first time a deprecated binding is called
+- Continue to execute the binding normally (deprecation is not removal)
+- Include the migration message in the warning
+
+### Backward Compatibility
+
+When a manifest's major version increments, scripts written for the previous major version may break. Host applications should document breaking changes and consider supporting a compatibility mode during the transition.
+
+The `xript` spec version (e.g., `"0.1"`) is separate from the manifest API version. A new spec version does not require a new API version — they track different things.
+
+## Manifest-to-TypeScript Mapping
+
+The typegen tool generates TypeScript definitions from the manifest. These are the mapping rules:
+
+### Primitive Types
+
+| Manifest Type | TypeScript Type |
+|---------------|----------------|
+| `"string"` | `string` |
+| `"number"` | `number` |
+| `"boolean"` | `boolean` |
+| `"void"` | `void` |
+| `"null"` | `null` |
+
+### Complex Types
+
+| Manifest Expression | TypeScript Type |
+|--------------------|----------------|
+| `"string[]"` | `string[]` |
+| `{ "array": "Position" }` | `Position[]` |
+| `{ "union": ["string", "number"] }` | `string \| number` |
+| `{ "map": "number" }` | `Record<string, number>` |
+| `{ "optional": "string" }` | `string \| undefined` |
+
+### Custom Types
+
+Object types become interfaces:
+
+```json
+{
+  "Position": {
+    "description": "A 2D position.",
+    "fields": {
+      "x": { "type": "number", "description": "Horizontal position." },
+      "y": { "type": "number", "description": "Vertical position." }
+    }
+  }
+}
+```
+
+Generates:
+
+```typescript
+/** A 2D position. */
+interface Position {
+  /** Horizontal position. */
+  x: number;
+  /** Vertical position. */
+  y: number;
+}
+```
+
+Enum types become string literal unions:
+
+```json
+{
+  "Direction": {
+    "description": "A cardinal direction.",
+    "values": ["north", "south", "east", "west"]
+  }
+}
+```
+
+Generates:
+
+```typescript
+/** A cardinal direction. */
+type Direction = "north" | "south" | "east" | "west";
+```
+
+### Function Bindings
+
+Function bindings generate typed function declarations with JSDoc:
+
+```json
+{
+  "setHealth": {
+    "description": "Sets the player's health.",
+    "params": [
+      { "name": "value", "type": "number", "description": "The new health value." }
+    ],
+    "capability": "modify-player"
+  }
+}
+```
+
+Generates:
+
+```typescript
+/**
+ * Sets the player's health.
+ * @remarks Requires capability: `modify-player`
+ * @param value - The new health value.
+ */
+declare function setHealth(value: number): void;
+```
+
+### Namespace Bindings
+
+Namespace bindings generate typed namespace declarations:
+
+```typescript
+/** Player functions. */
+declare namespace player {
+  /** Returns the player's health. */
+  function getHealth(): number;
+
+  /**
+   * Sets the player's health.
+   * @remarks Requires capability: `modify-player`
+   */
+  function setHealth(value: number): void;
+}
+```
+
+### Async Bindings
+
+Bindings with `"async": true` wrap their return type in `Promise`:
+
+```typescript
+/** Reads a value from storage. */
+declare function get(key: string): Promise<string | undefined>;
+```
+
+### Optional Parameters
+
+Parameters with a `default` value or `"required": false` become optional:
+
+```typescript
+declare function greet(name: string, excited?: boolean): string;
+```
+
+## Naming Conventions
+
+### Function Names
+
+Binding function names should follow JavaScript conventions:
+- camelCase (`getHealth`, `setPlayerName`)
+- Verb-first for actions (`addItem`, `removeEnemy`, `setHealth`)
+- Adjective or noun for getters (`isAlive`, `currentLevel`, `getHealth`)
+
+### Namespace Names
+
+Namespace names should be lowercase nouns or noun phrases:
+- `player`, `world`, `inventory`, `data`
+- Not verbs (`modify`, `handle`, `process`)
+- Not plurals unless they represent collections (`enemies` for a collection manager, but `enemy` for operations on a single enemy)

--- a/docs/src/content/docs/spec/capabilities.md
+++ b/docs/src/content/docs/spec/capabilities.md
@@ -1,0 +1,134 @@
+---
+title: Capability Model
+description: How xript enforces its default-deny security posture through named capabilities.
+---
+
+The capability model defines how xript enforces its default-deny security posture. Every sensitive operation is gated behind a named capability that scripts must be explicitly granted before use. This document specifies how capabilities are declared, requested, granted, and enforced.
+
+## Core Principles
+
+1. **Default-deny.** Scripts start with zero capabilities. They can only call ungated bindings until capabilities are explicitly granted.
+2. **Explicit grants.** The host application decides which capabilities a script receives. Scripts cannot grant themselves capabilities.
+3. **No ambient authority.** Having one capability does not imply access to another. Each capability is independent.
+4. **Transparent to the modder.** Modders should always know which capabilities their script needs and what each one grants.
+
+## Declaring Capabilities
+
+Capabilities are declared in the manifest's `capabilities` section:
+
+```json
+{
+  "capabilities": {
+    "modify-player": {
+      "description": "Modify the player's stats, inventory, and equipment.",
+      "risk": "medium"
+    },
+    "network": {
+      "description": "Make HTTP requests to allowed domains.",
+      "risk": "high"
+    },
+    "storage": {
+      "description": "Read and write persistent data for this mod.",
+      "risk": "low"
+    }
+  }
+}
+```
+
+Each capability has:
+- **`description`** (required): A human-readable explanation of what the capability grants. This is shown to users when a script requests it.
+- **`risk`** (`low`, `medium`, `high`): An advisory level that helps users make informed decisions. Does not affect runtime behavior.
+
+### Naming Conventions
+
+Capability names should be:
+- Lowercase with hyphens (`modify-player`, not `modifyPlayer` or `MODIFY_PLAYER`)
+- Action-oriented when possible (`read-files`, `modify-world`, `send-messages`)
+- Scoped by domain when the API is large (`player-read`, `player-write`, `world-read`, `world-write`)
+
+## Gating Bindings
+
+Individual functions are gated by referencing a capability name in their `capability` field:
+
+```json
+{
+  "bindings": {
+    "player": {
+      "description": "Player functions.",
+      "members": {
+        "getHealth": {
+          "description": "Returns the player's health.",
+          "returns": "number"
+        },
+        "setHealth": {
+          "description": "Sets the player's health.",
+          "params": [{ "name": "value", "type": "number" }],
+          "capability": "modify-player"
+        }
+      }
+    }
+  }
+}
+```
+
+In this example, `player.getHealth()` is always available (no `capability` field), but `player.setHealth()` requires the `modify-player` capability.
+
+### Ungated Bindings
+
+Functions without a `capability` field are accessible to all scripts unconditionally. This is the common case for read-only operations that pose no risk. The manifest author decides what is gated — the default is "available."
+
+### Multiple Capabilities
+
+A function can reference at most one capability. If a function logically requires multiple permissions, either:
+- Create a composite capability (e.g., `admin` that implies broad access)
+- Split the function into smaller, individually-gated functions
+
+The manifest does not support listing multiple capabilities per function. This is intentional: the simplicity of "one function, one gate" makes the model easy to reason about for both integrators and modders.
+
+## Runtime Behavior
+
+### Capability Lifecycle
+
+1. **Declaration**: The manifest declares which capabilities exist and which bindings they gate.
+2. **Request**: When a script is loaded, the runtime inspects which capabilities it needs (determined by which gated functions it calls, or declared in a script manifest).
+3. **Grant decision**: The host application receives the capability request and decides whether to grant each one. This decision is application-specific — it might be automatic, user-prompted, or policy-driven.
+4. **Enforcement**: The runtime makes only granted capabilities available. Calls to gated functions without the required capability fail with a `CapabilityDeniedError`.
+
+### Calling a Gated Function Without the Capability
+
+When a script calls a function it doesn't have the capability for, the runtime must:
+1. Throw a `CapabilityDeniedError` with a clear message including the capability name
+2. Not execute the function (no partial execution, no side effects)
+3. Allow the script to catch the error and continue running
+
+Example error message: `CapabilityDeniedError: calling "player.setHealth" requires the "modify-player" capability, which has not been granted to this script.`
+
+### Capability Grants Are Immutable
+
+Once a script's capabilities are set at load time, they cannot change during execution. A script cannot request additional capabilities mid-run. This prevents escalation attacks and simplifies the security model.
+
+If a host application wants to support dynamic permission prompting, it should do so during the grant phase (before execution begins), not during script execution.
+
+## Capability Discovery
+
+Modders need to know which capabilities exist and what they grant. The manifest provides this information:
+
+- **Tooling**: `xript-validate` can list all capabilities and which functions they gate
+- **Typegen**: Generated TypeScript types include JSDoc annotations indicating which functions require capabilities
+- **Docgen**: Generated documentation groups functions by capability requirement
+
+A modder writing a script should be able to look at the generated types or docs and immediately see: "I need `modify-player` to use `player.setHealth()` and `player.addItem()`."
+
+## Design Rationale
+
+### Why Not Role-Based Access Control?
+
+RBAC introduces complexity: roles, role hierarchies, role assignments. xript's capability model is deliberately simpler. Capabilities are flat (no hierarchy), binary (granted or not), and bound directly to functions. This maps cleanly to the manifest structure and is easy to validate statically.
+
+### Why Not Per-Invocation Grants?
+
+Checking capabilities on every function call would add runtime overhead and require the host to maintain per-call permission state. Per-script grants are simpler, faster, and match the mental model: "this script is allowed to do these things."
+
+### Why Advisory Risk Levels Instead of Enforced Tiers?
+
+The `risk` field is advisory because risk is context-dependent. Writing to storage might be `low` risk for a game mod but `high` risk for a financial tool. The manifest author sets the risk level based on their application's context; the runtime shows it to users but doesn't enforce behavior differences.

--- a/docs/src/content/docs/spec/security.md
+++ b/docs/src/content/docs/spec/security.md
@@ -1,0 +1,238 @@
+---
+title: Security Guarantees
+description: The security guarantees xript runtimes must provide — sandbox isolation, resource limits, capability enforcement, and eval prohibition.
+---
+
+This document defines the security guarantees that xript-conformant runtimes must provide. These guarantees exist so that users running third-party scripts never have to wonder whether a script is safe. It is safe. That is the contract.
+
+The guarantees formalize the four safety principles from the vision: no sandbox escape, no denial of service, no implicit trust, and no eval. Each guarantee includes the specific runtime behavior required, the failure mode when violated, and testable conformance criteria.
+
+## The Four Guarantees
+
+### 1. No Sandbox Escape
+
+Scripts cannot access anything the host has not explicitly exposed through bindings declared in the manifest.
+
+**What this means concretely:**
+
+- Scripts have no access to the host's file system, network, processes, or environment variables unless a binding explicitly provides it
+- Scripts cannot import or require modules outside the runtime's provided environment
+- Scripts cannot access or modify the host application's internal state except through declared bindings
+- Scripts cannot access other scripts' state or memory
+- The global scope available to scripts contains only: the language built-ins (as restricted below), the declared bindings, and nothing else
+
+**Host object isolation:**
+
+Objects returned from bindings must be copies or proxies, not direct references to host-internal objects. A script receiving a player position object must not be able to traverse prototype chains or property references to reach host internals. Runtimes should either deep-copy returned values or use membrane patterns that intercept property access.
+
+**Failure mode:** If a script attempts to access something outside the sandbox (e.g., through a prototype chain exploit or a globalThis property not in the allowed set), the access must return `undefined` or throw a `TypeError`. It must never succeed silently.
+
+### 2. No Denial of Service
+
+Scripts cannot consume unbounded resources. The manifest's `executionLimits` section declares the bounds, and the runtime enforces them.
+
+**Execution time:**
+
+Every script invocation has a maximum wall-clock duration. The default is 5000ms. When the timeout is reached, the runtime must terminate the script. Termination is immediate — the script does not get a grace period or a chance to clean up.
+
+**Memory:**
+
+Every script invocation has a maximum memory allocation. The default is 64 MB. When the limit is reached, the runtime must terminate the script. The memory limit covers the script's heap allocations, not the runtime's own overhead.
+
+**Stack depth:**
+
+Every script invocation has a maximum call stack depth. The default is 256 frames. When the limit is reached, the runtime must throw a `RangeError` (the standard JavaScript stack overflow error). Unlike timeout and memory violations, stack overflow is catchable — a script can catch the `RangeError` and continue operating within its remaining resource budget.
+
+**Infinite loop protection:**
+
+Runtimes must detect and terminate scripts that enter infinite loops or infinite recursion. The timeout limit is the primary mechanism for this, but runtimes may additionally instrument loops with iteration counters for faster detection.
+
+**Failure modes by resource:**
+
+| Resource | Limit Source | Failure | Catchable? |
+|----------|-------------|---------|------------|
+| Time | `executionLimits.timeout_ms` | Script terminated | No |
+| Memory | `executionLimits.memory_mb` | Script terminated | No |
+| Stack | `executionLimits.max_stack_depth` | `RangeError` thrown | Yes |
+
+Timeout and memory violations are not catchable because a script that has exhausted these resources cannot be trusted to handle errors correctly. Stack overflow is catchable because the stack unwinds naturally and the script may have legitimate recovery logic (e.g., switching from recursive to iterative algorithms).
+
+### 3. No Implicit Trust
+
+Scripts start with zero capabilities and can only call ungated bindings until capabilities are explicitly granted by the host. This guarantee is the enforcement side of the [capability model](/spec/capabilities).
+
+**Default-deny posture:**
+
+When a script is loaded, it has access to ungated bindings only. The host must explicitly grant each capability the script needs. There is no "allow all" shortcut in the spec — if a host application wants to grant everything, it must enumerate every capability.
+
+**Grant immutability:**
+
+Once a script's capability set is determined at load time, it cannot change during execution. Scripts cannot request additional capabilities mid-run. The host cannot revoke capabilities from a running script (it can terminate the script entirely, but not selectively remove access).
+
+**No transitive trust:**
+
+Having capability A does not imply access to capability B, even if A and B are related. Each capability is independent and must be granted individually.
+
+**No script-to-script trust:**
+
+Scripts cannot grant capabilities to other scripts. Only the host makes grant decisions.
+
+**Failure mode:** Calling a gated function without the required capability throws a `CapabilityDeniedError`. The function does not execute — not partially, not with reduced functionality. The error is catchable, and the script continues running with its existing capabilities.
+
+### 4. No Eval
+
+Scripts cannot dynamically generate and execute code. The `eval()` function, the `Function()` constructor, and any other mechanism for runtime code generation must be unavailable.
+
+**What is prohibited:**
+
+- `eval(string)`
+- `new Function(string)`
+- `setTimeout(string, ms)` and `setInterval(string, ms)` (the string overloads; callback overloads may be allowed if the runtime supports timers)
+- `import()` (dynamic import expressions)
+- Any runtime-specific mechanism that converts strings to executable code
+
+**Why this matters:**
+
+Dynamic code generation is the primary vector for code injection attacks in scripting environments. A script that can construct and execute arbitrary code can bypass every other security guarantee. Banning eval at the runtime level closes this vector entirely.
+
+**What modders should use instead:**
+
+- Data-driven dispatch: Use objects or maps to select behavior based on runtime values
+- Higher-order functions: Pass functions as arguments rather than constructing them from strings
+- Configuration objects: Express dynamic behavior through data structures, not code strings
+
+**Failure mode:** Calling `eval()`, `new Function()`, or any prohibited code generation mechanism must throw a `TypeError` with a clear message indicating that dynamic code generation is not permitted. The error is catchable.
+
+## Restricted Global Environment
+
+The runtime must provide a restricted global environment that excludes dangerous APIs while preserving JavaScript's core functionality.
+
+### Must Be Available
+
+These are required for scripts to function as normal JavaScript:
+
+- All primitive types and their prototypes (`String`, `Number`, `Boolean`, `Symbol`, `BigInt`)
+- `Object`, `Array`, `Map`, `Set`, `WeakMap`, `WeakSet`
+- `Promise`, `async`/`await` support
+- `JSON.parse()`, `JSON.stringify()`
+- `Math`, `Date` (read-only current time; whether `Date.now()` returns real time or simulated time is host-determined)
+- `Error`, `TypeError`, `RangeError`, `SyntaxError`, `ReferenceError`
+- `RegExp`
+- `console.log()`, `console.warn()`, `console.error()` (output routed to the host's mod console)
+- Structured clone algorithm types (`ArrayBuffer`, `DataView`, typed arrays)
+- `Proxy`, `Reflect` (scripts may use these on their own objects)
+- `globalThis` (pointing to the restricted global, not the host's global)
+
+### Must Be Unavailable
+
+These must not be accessible to scripts:
+
+- `eval`, `Function` constructor (covered by the no-eval guarantee)
+- `import`, `require`, `importScripts` (no module loading)
+- `fetch`, `XMLHttpRequest`, `WebSocket` (no network access unless provided by a binding)
+- `setTimeout`, `setInterval`, `requestAnimationFrame` (no timers unless provided by a binding)
+- `process`, `Deno`, `window`, `document`, `navigator` (no platform globals)
+- `SharedArrayBuffer`, `Atomics` (no shared memory with host)
+- `Worker`, `ServiceWorker` (no thread spawning)
+- `__proto__` mutation (prototype chain must be frozen)
+
+### Host-Determined
+
+These may or may not be available depending on the host's security requirements:
+
+- `structuredClone` (safe but some hosts may omit it)
+- `TextEncoder`, `TextDecoder` (safe but adds surface area)
+- `crypto.getRandomValues()` (safe for generating random data; `crypto.subtle` should be unavailable unless needed)
+- `Intl` formatting APIs (safe but adds surface area)
+- Iterator and generator support (safe, generally should be available)
+
+## Trust Model
+
+The xript trust model defines the relationships between the four actors in the system.
+
+### Actors
+
+| Actor | Description |
+|-------|-------------|
+| **Host application** | The software that embeds xript. It defines the manifest and runs the runtime. |
+| **Runtime** | The JavaScript execution environment that enforces security guarantees. |
+| **Script** | User-authored code that runs inside the runtime. |
+| **User** | The person who decides which scripts to run and which capabilities to grant. |
+
+### Trust Relationships
+
+**The user trusts the host application.** By installing and running the application, the user extends trust to it. The host application is responsible for providing accurate manifests and a conformant runtime.
+
+**The host application trusts the runtime.** The host delegates script execution to the runtime and trusts it to enforce the security guarantees. If the runtime is non-conformant, the host's security promises are void.
+
+**Nobody trusts scripts by default.** Scripts are untrusted code from the user's perspective. The capability model exists precisely because scripts cannot be assumed safe. Users grant capabilities based on their own risk assessment, informed by the manifest's capability descriptions and risk levels.
+
+**The runtime does not trust scripts.** The runtime enforces all guarantees regardless of which capabilities a script has been granted. A script with every capability is still sandboxed, still resource-limited, and still prohibited from eval.
+
+### What Trust Does Not Flow Through
+
+- A trusted script does not make other scripts trusted
+- A capability grant does not imply trust in the script's intentions, only permission for specific operations
+- The host application's trust in the runtime does not extend to scripts the runtime executes
+
+## Conformance Checklist
+
+Runtime implementors must verify their implementation against each item in this checklist. A conformant runtime passes all items.
+
+### Sandbox Isolation
+
+- [ ] Scripts cannot access host file system, network, or environment without explicit bindings
+- [ ] Scripts cannot import or require external modules
+- [ ] Scripts cannot access other scripts' state
+- [ ] Objects returned from bindings do not expose host internals through prototype traversal
+- [ ] The global scope contains only language built-ins, declared bindings, and nothing else
+- [ ] Accessing undefined globals returns `undefined` or throws `ReferenceError`, never host data
+
+### Resource Limits
+
+- [ ] Scripts exceeding `timeout_ms` are terminated (not catchable)
+- [ ] Scripts exceeding `memory_mb` are terminated (not catchable)
+- [ ] Scripts exceeding `max_stack_depth` receive a `RangeError` (catchable)
+- [ ] Infinite loops are terminated by the timeout mechanism
+- [ ] Default limits (5000ms, 64MB, 256 stack frames) are applied when the manifest omits `executionLimits`
+- [ ] After termination, the runtime is in a clean state (no leaked resources, no corrupted host state)
+
+### Capability Enforcement
+
+- [ ] Scripts start with zero capabilities
+- [ ] Calling a gated function without the capability throws `CapabilityDeniedError`
+- [ ] The gated function does not partially execute on capability denial
+- [ ] Capabilities cannot be added or removed during script execution
+- [ ] Scripts cannot grant capabilities to themselves or other scripts
+
+### Eval Prohibition
+
+- [ ] `eval()` throws `TypeError`
+- [ ] `new Function()` throws `TypeError`
+- [ ] `setTimeout(string)` throws `TypeError` or is unavailable
+- [ ] `setInterval(string)` throws `TypeError` or is unavailable
+- [ ] `import()` expressions are unavailable
+- [ ] No other mechanism for string-to-code conversion exists
+
+### Global Environment
+
+- [ ] All "must be available" APIs are present and functional
+- [ ] All "must be unavailable" APIs are absent or throw on access
+- [ ] `__proto__` mutation is prevented
+- [ ] `globalThis` points to the restricted global, not the host's
+- [ ] Prototype chains of built-in objects are frozen or otherwise tamper-proof
+
+### Error Handling
+
+- [ ] Security violations produce clear, descriptive error messages
+- [ ] Error messages do not leak host implementation details (no host stack traces, no internal paths)
+- [ ] Catchable errors (`CapabilityDeniedError`, `TypeError` from eval, `RangeError` from stack overflow) allow the script to continue
+- [ ] Non-catchable terminations (timeout, memory) fully stop the script with no further execution
+
+## Relationship to Other Specifications
+
+The security guarantees build on and complement the other xript spec documents:
+
+- **[Manifest](/spec/manifest)**: Declares `executionLimits` that this document's resource guarantees enforce. Also declares capabilities that the trust model relies on.
+- **[Capabilities](/spec/capabilities)**: Defines the capability model that this document's "no implicit trust" guarantee enforces. The capability spec covers declaration and lifecycle; this document covers the security properties those mechanisms must provide.
+- **[Bindings](/spec/bindings)**: Defines how bindings behave at runtime, including the error types (`BindingError`, `CapabilityDeniedError`, `TypeError`) referenced throughout this document.

--- a/spec/README.md
+++ b/spec/README.md
@@ -7,9 +7,6 @@ The xript specification defines how applications expose functionality to scripts
 - [vision.md](./vision.md) — the guiding vision for xript
 - [manifest.md](./manifest.md) — the manifest format specification
 - [manifest.schema.json](./manifest.schema.json) — the manifest JSON Schema
-
-## Planned
-
-- Capability model
-- Binding conventions
-- Security guarantees
+- [capabilities.md](./capabilities.md) — the capability model
+- [bindings.md](./bindings.md) — binding conventions and type mapping
+- [security.md](./security.md) — security guarantees and conformance checklist

--- a/spec/bindings.md
+++ b/spec/bindings.md
@@ -1,0 +1,234 @@
+# xript Binding Conventions
+
+Bindings are the bridge between the host application and modder scripts. The [manifest schema](./manifest.md) defines how bindings are declared. This document covers the runtime conventions that govern how bindings behave: error handling, versioning, and the mapping from manifest declarations to generated TypeScript types.
+
+## Error Handling
+
+### Host-Side Errors
+
+When a binding function throws an error inside the host application, the runtime must:
+
+1. **Catch the error** before it propagates to the script
+2. **Wrap it** in a `BindingError` with:
+   - The original error message
+   - The binding name (e.g., `"player.setHealth"`)
+   - No stack trace from the host (this would leak implementation details outside the sandbox)
+3. **Throw the `BindingError`** into the script context so the modder can catch and handle it
+
+Example from the modder's perspective:
+
+```javascript
+try {
+  player.setHealth(-1);
+} catch (e) {
+  // e.name === "BindingError"
+  // e.message === "player.setHealth: health value must be non-negative"
+  // e.binding === "player.setHealth"
+  log(e.message);
+}
+```
+
+### Script-Side Error Handling
+
+Modders can wrap binding calls in try/catch. Uncaught errors from bindings terminate the script with the error message logged to the host's mod console.
+
+### Error Types
+
+The runtime provides these error types to scripts:
+
+| Error | When Thrown |
+|-------|------------|
+| `BindingError` | A binding function failed during execution |
+| `CapabilityDeniedError` | A gated function was called without the required capability |
+| `TypeError` | Arguments don't match the binding's declared parameter types |
+
+Runtimes may add additional error types, but these three must be present.
+
+### Type Validation
+
+Runtimes should validate argument types before invoking the host binding. If a binding declares `params: [{ "name": "value", "type": "number" }]` and the modder passes a string, the runtime should throw a `TypeError` without calling the host function. This prevents unexpected values from reaching the host and provides clear feedback to the modder.
+
+Type validation is recommended but not strictly required — some runtimes may defer to the host's own type checking for performance reasons.
+
+## Versioning
+
+### API Versioning Through the Manifest
+
+The manifest's `version` field tracks the scripting API version using semver:
+
+- **Patch** (1.0.x): Bug fixes in binding behavior. No signature changes.
+- **Minor** (1.x.0): New bindings added. Existing bindings unchanged.
+- **Major** (x.0.0): Breaking changes to existing binding signatures or behavior.
+
+### Deprecation
+
+Bindings can be marked deprecated in the manifest:
+
+```json
+{
+  "getHP": {
+    "description": "Returns the player's health.",
+    "returns": "number",
+    "deprecated": "Use player.getHealth() instead."
+  }
+}
+```
+
+Runtimes should:
+- Log a deprecation warning the first time a deprecated binding is called
+- Continue to execute the binding normally (deprecation is not removal)
+- Include the migration message in the warning
+
+### Backward Compatibility
+
+When a manifest's major version increments, scripts written for the previous major version may break. Host applications should document breaking changes and consider supporting a compatibility mode during the transition.
+
+The `xript` spec version (e.g., `"0.1"`) is separate from the manifest API version. A new spec version does not require a new API version — they track different things.
+
+## Manifest-to-TypeScript Mapping
+
+The typegen tool generates TypeScript definitions from the manifest. These are the mapping rules:
+
+### Primitive Types
+
+| Manifest Type | TypeScript Type |
+|---------------|----------------|
+| `"string"` | `string` |
+| `"number"` | `number` |
+| `"boolean"` | `boolean` |
+| `"void"` | `void` |
+| `"null"` | `null` |
+
+### Complex Types
+
+| Manifest Expression | TypeScript Type |
+|--------------------|----------------|
+| `"string[]"` | `string[]` |
+| `{ "array": "Position" }` | `Position[]` |
+| `{ "union": ["string", "number"] }` | `string \| number` |
+| `{ "map": "number" }` | `Record<string, number>` |
+| `{ "optional": "string" }` | `string \| undefined` |
+
+### Custom Types
+
+Object types become interfaces:
+
+```json
+{
+  "Position": {
+    "description": "A 2D position.",
+    "fields": {
+      "x": { "type": "number", "description": "Horizontal position." },
+      "y": { "type": "number", "description": "Vertical position." }
+    }
+  }
+}
+```
+
+Generates:
+
+```typescript
+/** A 2D position. */
+interface Position {
+  /** Horizontal position. */
+  x: number;
+  /** Vertical position. */
+  y: number;
+}
+```
+
+Enum types become string literal unions:
+
+```json
+{
+  "Direction": {
+    "description": "A cardinal direction.",
+    "values": ["north", "south", "east", "west"]
+  }
+}
+```
+
+Generates:
+
+```typescript
+/** A cardinal direction. */
+type Direction = "north" | "south" | "east" | "west";
+```
+
+### Function Bindings
+
+Function bindings generate typed function declarations with JSDoc:
+
+```json
+{
+  "setHealth": {
+    "description": "Sets the player's health.",
+    "params": [
+      { "name": "value", "type": "number", "description": "The new health value." }
+    ],
+    "capability": "modify-player"
+  }
+}
+```
+
+Generates:
+
+```typescript
+/**
+ * Sets the player's health.
+ * @remarks Requires capability: `modify-player`
+ * @param value - The new health value.
+ */
+declare function setHealth(value: number): void;
+```
+
+### Namespace Bindings
+
+Namespace bindings generate typed namespace declarations:
+
+```typescript
+/** Player functions. */
+declare namespace player {
+  /** Returns the player's health. */
+  function getHealth(): number;
+
+  /**
+   * Sets the player's health.
+   * @remarks Requires capability: `modify-player`
+   */
+  function setHealth(value: number): void;
+}
+```
+
+### Async Bindings
+
+Bindings with `"async": true` wrap their return type in `Promise`:
+
+```typescript
+/** Reads a value from storage. */
+declare function get(key: string): Promise<string | undefined>;
+```
+
+### Optional Parameters
+
+Parameters with a `default` value or `"required": false` become optional:
+
+```typescript
+declare function greet(name: string, excited?: boolean): string;
+```
+
+## Naming Conventions
+
+### Function Names
+
+Binding function names should follow JavaScript conventions:
+- camelCase (`getHealth`, `setPlayerName`)
+- Verb-first for actions (`addItem`, `removeEnemy`, `setHealth`)
+- Adjective or noun for getters (`isAlive`, `currentLevel`, `getHealth`)
+
+### Namespace Names
+
+Namespace names should be lowercase nouns or noun phrases:
+- `player`, `world`, `inventory`, `data`
+- Not verbs (`modify`, `handle`, `process`)
+- Not plurals unless they represent collections (`enemies` for a collection manager, but `enemy` for operations on a single enemy)

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -1,0 +1,131 @@
+# xript Capability Model
+
+The capability model defines how xript enforces its default-deny security posture. Every sensitive operation is gated behind a named capability that scripts must be explicitly granted before use. This document specifies how capabilities are declared, requested, granted, and enforced.
+
+## Core Principles
+
+1. **Default-deny.** Scripts start with zero capabilities. They can only call ungated bindings until capabilities are explicitly granted.
+2. **Explicit grants.** The host application decides which capabilities a script receives. Scripts cannot grant themselves capabilities.
+3. **No ambient authority.** Having one capability does not imply access to another. Each capability is independent.
+4. **Transparent to the modder.** Modders should always know which capabilities their script needs and what each one grants.
+
+## Declaring Capabilities
+
+Capabilities are declared in the manifest's `capabilities` section:
+
+```json
+{
+  "capabilities": {
+    "modify-player": {
+      "description": "Modify the player's stats, inventory, and equipment.",
+      "risk": "medium"
+    },
+    "network": {
+      "description": "Make HTTP requests to allowed domains.",
+      "risk": "high"
+    },
+    "storage": {
+      "description": "Read and write persistent data for this mod.",
+      "risk": "low"
+    }
+  }
+}
+```
+
+Each capability has:
+- **`description`** (required): A human-readable explanation of what the capability grants. This is shown to users when a script requests it.
+- **`risk`** (`low`, `medium`, `high`): An advisory level that helps users make informed decisions. Does not affect runtime behavior.
+
+### Naming Conventions
+
+Capability names should be:
+- Lowercase with hyphens (`modify-player`, not `modifyPlayer` or `MODIFY_PLAYER`)
+- Action-oriented when possible (`read-files`, `modify-world`, `send-messages`)
+- Scoped by domain when the API is large (`player-read`, `player-write`, `world-read`, `world-write`)
+
+## Gating Bindings
+
+Individual functions are gated by referencing a capability name in their `capability` field:
+
+```json
+{
+  "bindings": {
+    "player": {
+      "description": "Player functions.",
+      "members": {
+        "getHealth": {
+          "description": "Returns the player's health.",
+          "returns": "number"
+        },
+        "setHealth": {
+          "description": "Sets the player's health.",
+          "params": [{ "name": "value", "type": "number" }],
+          "capability": "modify-player"
+        }
+      }
+    }
+  }
+}
+```
+
+In this example, `player.getHealth()` is always available (no `capability` field), but `player.setHealth()` requires the `modify-player` capability.
+
+### Ungated Bindings
+
+Functions without a `capability` field are accessible to all scripts unconditionally. This is the common case for read-only operations that pose no risk. The manifest author decides what is gated — the default is "available."
+
+### Multiple Capabilities
+
+A function can reference at most one capability. If a function logically requires multiple permissions, either:
+- Create a composite capability (e.g., `admin` that implies broad access)
+- Split the function into smaller, individually-gated functions
+
+The manifest does not support listing multiple capabilities per function. This is intentional: the simplicity of "one function, one gate" makes the model easy to reason about for both integrators and modders.
+
+## Runtime Behavior
+
+### Capability Lifecycle
+
+1. **Declaration**: The manifest declares which capabilities exist and which bindings they gate.
+2. **Request**: When a script is loaded, the runtime inspects which capabilities it needs (determined by which gated functions it calls, or declared in a script manifest).
+3. **Grant decision**: The host application receives the capability request and decides whether to grant each one. This decision is application-specific — it might be automatic, user-prompted, or policy-driven.
+4. **Enforcement**: The runtime makes only granted capabilities available. Calls to gated functions without the required capability fail with a `CapabilityDeniedError`.
+
+### Calling a Gated Function Without the Capability
+
+When a script calls a function it doesn't have the capability for, the runtime must:
+1. Throw a `CapabilityDeniedError` with a clear message including the capability name
+2. Not execute the function (no partial execution, no side effects)
+3. Allow the script to catch the error and continue running
+
+Example error message: `CapabilityDeniedError: calling "player.setHealth" requires the "modify-player" capability, which has not been granted to this script.`
+
+### Capability Grants Are Immutable
+
+Once a script's capabilities are set at load time, they cannot change during execution. A script cannot request additional capabilities mid-run. This prevents escalation attacks and simplifies the security model.
+
+If a host application wants to support dynamic permission prompting, it should do so during the grant phase (before execution begins), not during script execution.
+
+## Capability Discovery
+
+Modders need to know which capabilities exist and what they grant. The manifest provides this information:
+
+- **Tooling**: `xript-validate` can list all capabilities and which functions they gate
+- **Typegen**: Generated TypeScript types include JSDoc annotations indicating which functions require capabilities
+- **Docgen**: Generated documentation groups functions by capability requirement
+
+A modder writing a script should be able to look at the generated types or docs and immediately see: "I need `modify-player` to use `player.setHealth()` and `player.addItem()`."
+
+## Design Rationale
+
+### Why Not Role-Based Access Control?
+
+RBAC introduces complexity: roles, role hierarchies, role assignments. xript's capability model is deliberately simpler. Capabilities are flat (no hierarchy), binary (granted or not), and bound directly to functions. This maps cleanly to the manifest structure and is easy to validate statically.
+
+### Why Not Per-Invocation Grants?
+
+Checking capabilities on every function call would add runtime overhead and require the host to maintain per-call permission state. Per-script grants are simpler, faster, and match the mental model: "this script is allowed to do these things."
+
+### Why Advisory Risk Levels Instead of Enforced Tiers?
+
+The `risk` field is advisory because risk is context-dependent. Writing to storage might be `low` risk for a game mod but `high` risk for a financial tool. The manifest author sets the risk level based on their application's context; the runtime shows it to users but doesn't enforce behavior differences.

--- a/spec/security.md
+++ b/spec/security.md
@@ -1,0 +1,235 @@
+# xript Security Guarantees
+
+This document defines the security guarantees that xript-conformant runtimes must provide. These guarantees exist so that users running third-party scripts never have to wonder whether a script is safe. It is safe. That is the contract.
+
+The guarantees formalize the four safety principles from the vision: no sandbox escape, no denial of service, no implicit trust, and no eval. Each guarantee includes the specific runtime behavior required, the failure mode when violated, and testable conformance criteria.
+
+## The Four Guarantees
+
+### 1. No Sandbox Escape
+
+Scripts cannot access anything the host has not explicitly exposed through bindings declared in the manifest.
+
+**What this means concretely:**
+
+- Scripts have no access to the host's file system, network, processes, or environment variables unless a binding explicitly provides it
+- Scripts cannot import or require modules outside the runtime's provided environment
+- Scripts cannot access or modify the host application's internal state except through declared bindings
+- Scripts cannot access other scripts' state or memory
+- The global scope available to scripts contains only: the language built-ins (as restricted below), the declared bindings, and nothing else
+
+**Host object isolation:**
+
+Objects returned from bindings must be copies or proxies, not direct references to host-internal objects. A script receiving a player position object must not be able to traverse prototype chains or property references to reach host internals. Runtimes should either deep-copy returned values or use membrane patterns that intercept property access.
+
+**Failure mode:** If a script attempts to access something outside the sandbox (e.g., through a prototype chain exploit or a globalThis property not in the allowed set), the access must return `undefined` or throw a `TypeError`. It must never succeed silently.
+
+### 2. No Denial of Service
+
+Scripts cannot consume unbounded resources. The manifest's `executionLimits` section declares the bounds, and the runtime enforces them.
+
+**Execution time:**
+
+Every script invocation has a maximum wall-clock duration. The default is 5000ms. When the timeout is reached, the runtime must terminate the script. Termination is immediate — the script does not get a grace period or a chance to clean up.
+
+**Memory:**
+
+Every script invocation has a maximum memory allocation. The default is 64 MB. When the limit is reached, the runtime must terminate the script. The memory limit covers the script's heap allocations, not the runtime's own overhead.
+
+**Stack depth:**
+
+Every script invocation has a maximum call stack depth. The default is 256 frames. When the limit is reached, the runtime must throw a `RangeError` (the standard JavaScript stack overflow error). Unlike timeout and memory violations, stack overflow is catchable — a script can catch the `RangeError` and continue operating within its remaining resource budget.
+
+**Infinite loop protection:**
+
+Runtimes must detect and terminate scripts that enter infinite loops or infinite recursion. The timeout limit is the primary mechanism for this, but runtimes may additionally instrument loops with iteration counters for faster detection.
+
+**Failure modes by resource:**
+
+| Resource | Limit Source | Failure | Catchable? |
+|----------|-------------|---------|------------|
+| Time | `executionLimits.timeout_ms` | Script terminated | No |
+| Memory | `executionLimits.memory_mb` | Script terminated | No |
+| Stack | `executionLimits.max_stack_depth` | `RangeError` thrown | Yes |
+
+Timeout and memory violations are not catchable because a script that has exhausted these resources cannot be trusted to handle errors correctly. Stack overflow is catchable because the stack unwinds naturally and the script may have legitimate recovery logic (e.g., switching from recursive to iterative algorithms).
+
+### 3. No Implicit Trust
+
+Scripts start with zero capabilities and can only call ungated bindings until capabilities are explicitly granted by the host. This guarantee is the enforcement side of the [capability model](./capabilities.md).
+
+**Default-deny posture:**
+
+When a script is loaded, it has access to ungated bindings only. The host must explicitly grant each capability the script needs. There is no "allow all" shortcut in the spec — if a host application wants to grant everything, it must enumerate every capability.
+
+**Grant immutability:**
+
+Once a script's capability set is determined at load time, it cannot change during execution. Scripts cannot request additional capabilities mid-run. The host cannot revoke capabilities from a running script (it can terminate the script entirely, but not selectively remove access).
+
+**No transitive trust:**
+
+Having capability A does not imply access to capability B, even if A and B are related. Each capability is independent and must be granted individually.
+
+**No script-to-script trust:**
+
+Scripts cannot grant capabilities to other scripts. Only the host makes grant decisions.
+
+**Failure mode:** Calling a gated function without the required capability throws a `CapabilityDeniedError`. The function does not execute — not partially, not with reduced functionality. The error is catchable, and the script continues running with its existing capabilities.
+
+### 4. No Eval
+
+Scripts cannot dynamically generate and execute code. The `eval()` function, the `Function()` constructor, and any other mechanism for runtime code generation must be unavailable.
+
+**What is prohibited:**
+
+- `eval(string)`
+- `new Function(string)`
+- `setTimeout(string, ms)` and `setInterval(string, ms)` (the string overloads; callback overloads may be allowed if the runtime supports timers)
+- `import()` (dynamic import expressions)
+- Any runtime-specific mechanism that converts strings to executable code
+
+**Why this matters:**
+
+Dynamic code generation is the primary vector for code injection attacks in scripting environments. A script that can construct and execute arbitrary code can bypass every other security guarantee. Banning eval at the runtime level closes this vector entirely.
+
+**What modders should use instead:**
+
+- Data-driven dispatch: Use objects or maps to select behavior based on runtime values
+- Higher-order functions: Pass functions as arguments rather than constructing them from strings
+- Configuration objects: Express dynamic behavior through data structures, not code strings
+
+**Failure mode:** Calling `eval()`, `new Function()`, or any prohibited code generation mechanism must throw a `TypeError` with a clear message indicating that dynamic code generation is not permitted. The error is catchable.
+
+## Restricted Global Environment
+
+The runtime must provide a restricted global environment that excludes dangerous APIs while preserving JavaScript's core functionality.
+
+### Must Be Available
+
+These are required for scripts to function as normal JavaScript:
+
+- All primitive types and their prototypes (`String`, `Number`, `Boolean`, `Symbol`, `BigInt`)
+- `Object`, `Array`, `Map`, `Set`, `WeakMap`, `WeakSet`
+- `Promise`, `async`/`await` support
+- `JSON.parse()`, `JSON.stringify()`
+- `Math`, `Date` (read-only current time; whether `Date.now()` returns real time or simulated time is host-determined)
+- `Error`, `TypeError`, `RangeError`, `SyntaxError`, `ReferenceError`
+- `RegExp`
+- `console.log()`, `console.warn()`, `console.error()` (output routed to the host's mod console)
+- Structured clone algorithm types (`ArrayBuffer`, `DataView`, typed arrays)
+- `Proxy`, `Reflect` (scripts may use these on their own objects)
+- `globalThis` (pointing to the restricted global, not the host's global)
+
+### Must Be Unavailable
+
+These must not be accessible to scripts:
+
+- `eval`, `Function` constructor (covered by the no-eval guarantee)
+- `import`, `require`, `importScripts` (no module loading)
+- `fetch`, `XMLHttpRequest`, `WebSocket` (no network access unless provided by a binding)
+- `setTimeout`, `setInterval`, `requestAnimationFrame` (no timers unless provided by a binding)
+- `process`, `Deno`, `window`, `document`, `navigator` (no platform globals)
+- `SharedArrayBuffer`, `Atomics` (no shared memory with host)
+- `Worker`, `ServiceWorker` (no thread spawning)
+- `__proto__` mutation (prototype chain must be frozen)
+
+### Host-Determined
+
+These may or may not be available depending on the host's security requirements:
+
+- `structuredClone` (safe but some hosts may omit it)
+- `TextEncoder`, `TextDecoder` (safe but adds surface area)
+- `crypto.getRandomValues()` (safe for generating random data; `crypto.subtle` should be unavailable unless needed)
+- `Intl` formatting APIs (safe but adds surface area)
+- Iterator and generator support (safe, generally should be available)
+
+## Trust Model
+
+The xript trust model defines the relationships between the four actors in the system.
+
+### Actors
+
+| Actor | Description |
+|-------|-------------|
+| **Host application** | The software that embeds xript. It defines the manifest and runs the runtime. |
+| **Runtime** | The JavaScript execution environment that enforces security guarantees. |
+| **Script** | User-authored code that runs inside the runtime. |
+| **User** | The person who decides which scripts to run and which capabilities to grant. |
+
+### Trust Relationships
+
+**The user trusts the host application.** By installing and running the application, the user extends trust to it. The host application is responsible for providing accurate manifests and a conformant runtime.
+
+**The host application trusts the runtime.** The host delegates script execution to the runtime and trusts it to enforce the security guarantees. If the runtime is non-conformant, the host's security promises are void.
+
+**Nobody trusts scripts by default.** Scripts are untrusted code from the user's perspective. The capability model exists precisely because scripts cannot be assumed safe. Users grant capabilities based on their own risk assessment, informed by the manifest's capability descriptions and risk levels.
+
+**The runtime does not trust scripts.** The runtime enforces all guarantees regardless of which capabilities a script has been granted. A script with every capability is still sandboxed, still resource-limited, and still prohibited from eval.
+
+### What Trust Does Not Flow Through
+
+- A trusted script does not make other scripts trusted
+- A capability grant does not imply trust in the script's intentions, only permission for specific operations
+- The host application's trust in the runtime does not extend to scripts the runtime executes
+
+## Conformance Checklist
+
+Runtime implementors must verify their implementation against each item in this checklist. A conformant runtime passes all items.
+
+### Sandbox Isolation
+
+- [ ] Scripts cannot access host file system, network, or environment without explicit bindings
+- [ ] Scripts cannot import or require external modules
+- [ ] Scripts cannot access other scripts' state
+- [ ] Objects returned from bindings do not expose host internals through prototype traversal
+- [ ] The global scope contains only language built-ins, declared bindings, and nothing else
+- [ ] Accessing undefined globals returns `undefined` or throws `ReferenceError`, never host data
+
+### Resource Limits
+
+- [ ] Scripts exceeding `timeout_ms` are terminated (not catchable)
+- [ ] Scripts exceeding `memory_mb` are terminated (not catchable)
+- [ ] Scripts exceeding `max_stack_depth` receive a `RangeError` (catchable)
+- [ ] Infinite loops are terminated by the timeout mechanism
+- [ ] Default limits (5000ms, 64MB, 256 stack frames) are applied when the manifest omits `executionLimits`
+- [ ] After termination, the runtime is in a clean state (no leaked resources, no corrupted host state)
+
+### Capability Enforcement
+
+- [ ] Scripts start with zero capabilities
+- [ ] Calling a gated function without the capability throws `CapabilityDeniedError`
+- [ ] The gated function does not partially execute on capability denial
+- [ ] Capabilities cannot be added or removed during script execution
+- [ ] Scripts cannot grant capabilities to themselves or other scripts
+
+### Eval Prohibition
+
+- [ ] `eval()` throws `TypeError`
+- [ ] `new Function()` throws `TypeError`
+- [ ] `setTimeout(string)` throws `TypeError` or is unavailable
+- [ ] `setInterval(string)` throws `TypeError` or is unavailable
+- [ ] `import()` expressions are unavailable
+- [ ] No other mechanism for string-to-code conversion exists
+
+### Global Environment
+
+- [ ] All "must be available" APIs are present and functional
+- [ ] All "must be unavailable" APIs are absent or throw on access
+- [ ] `__proto__` mutation is prevented
+- [ ] `globalThis` points to the restricted global, not the host's
+- [ ] Prototype chains of built-in objects are frozen or otherwise tamper-proof
+
+### Error Handling
+
+- [ ] Security violations produce clear, descriptive error messages
+- [ ] Error messages do not leak host implementation details (no host stack traces, no internal paths)
+- [ ] Catchable errors (`CapabilityDeniedError`, `TypeError` from eval, `RangeError` from stack overflow) allow the script to continue
+- [ ] Non-catchable terminations (timeout, memory) fully stop the script with no further execution
+
+## Relationship to Other Specifications
+
+The security guarantees build on and complement the other xript spec documents:
+
+- **[Manifest](./manifest.md)**: Declares `executionLimits` that this document's resource guarantees enforce. Also declares capabilities that the trust model relies on.
+- **[Capabilities](./capabilities.md)**: Defines the capability model that this document's "no implicit trust" guarantee enforces. The capability spec covers declaration and lifecycle; this document covers the security properties those mechanisms must provide.
+- **[Bindings](./bindings.md)**: Defines how bindings behave at runtime, including the error types (`BindingError`, `CapabilityDeniedError`, `TypeError`) referenced throughout this document.


### PR DESCRIPTION
## Summary

- Wrote the three remaining spec documents to complete the Spec v0.1 milestone
- `spec/capabilities.md` (#3): capability model -- default-deny, gating bindings, runtime lifecycle, immutable grants
- `spec/bindings.md` (#4): binding conventions -- error handling, versioning/deprecation, manifest-to-TypeScript mapping
- `spec/security.md` (#5): security guarantees -- the four guarantees (no sandbox escape, no DoS, no implicit trust, no eval), restricted global environment, trust model, and conformance checklist for runtime implementors
- Added all three spec pages to the docs site sidebar and created corresponding Starlight doc pages
- Updated `spec/README.md` to reflect all completed documents

## Test plan

- [x] Docs build passes (7 pages, search index built)
- [x] All spec documents are accessible in the Starlight sidebar
- [x] Cross-references between spec documents use correct paths

Closes #3, closes #4, closes #5