### PR TITLE
build the docgen tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1834,6 +1834,10 @@
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"license": "ISC"
 		},
+		"node_modules/@xript/docgen": {
+			"resolved": "tools/docgen",
+			"link": true
+		},
 		"node_modules/@xript/docs": {
 			"resolved": "docs",
 			"link": true
@@ -6481,6 +6485,35 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"tools/docgen": {
+			"name": "@xript/docgen",
+			"version": "0.1.0",
+			"license": "MIT",
+			"bin": {
+				"xript-docgen": "dist/cli.js"
+			},
+			"devDependencies": {
+				"@types/node": "^22.0.0",
+				"typescript": "^5.7.0"
+			}
+		},
+		"tools/docgen/node_modules/@types/node": {
+			"version": "22.19.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.10.tgz",
+			"integrity": "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"tools/docgen/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"tools/manifest-validator": {
 			"name": "@xript/manifest-validator",

--- a/tools/README.md
+++ b/tools/README.md
@@ -6,8 +6,8 @@ Tooling for the xript ecosystem.
 
 - **manifest-validator/** (`@xript/manifest-validator`) — validate xript manifests against the spec schema
 - **typegen/** (`@xript/typegen`) — generate TypeScript definitions from manifests
+- **docgen/** (`@xript/docgen`) — generate markdown documentation from manifests
 
 ## Planned Tools
 
-- **docgen/** — generate documentation sites from manifests
 - **playground/** — interactive playground for testing scripts against manifests

--- a/tools/docgen/package.json
+++ b/tools/docgen/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "@xript/docgen",
+	"version": "0.1.0",
+	"description": "Generate documentation from xript manifests.",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"bin": {
+		"xript-docgen": "./dist/cli.js"
+	},
+	"scripts": {
+		"build": "tsc",
+		"test": "node --test test/*.test.js",
+		"prepublishOnly": "npm run build"
+	},
+	"keywords": ["xript", "docgen", "documentation", "markdown"],
+	"license": "MIT",
+	"devDependencies": {
+		"typescript": "^5.7.0",
+		"@types/node": "^22.0.0"
+	}
+}

--- a/tools/docgen/src/cli.ts
+++ b/tools/docgen/src/cli.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import { resolve } from "node:path";
+import { generateDocsFromFile, writeDocsToDirectory } from "./index.js";
+
+const args = process.argv.slice(2);
+
+if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+	console.log("Usage: xript-docgen <manifest.json> --output <directory>");
+	console.log("");
+	console.log("Generate markdown documentation from an xript manifest.");
+	console.log("");
+	console.log("Options:");
+	console.log("  --output, -o  Output directory (required)");
+	console.log("  --help, -h    Show this help message");
+	process.exit(args.length === 0 ? 1 : 0);
+}
+
+const outputIndex = args.findIndex((a) => a === "--output" || a === "-o");
+let outputDir: string | undefined;
+let manifestPath: string;
+
+if (outputIndex !== -1) {
+	outputDir = args[outputIndex + 1];
+	if (!outputDir) {
+		console.error("Error: --output requires a directory path.");
+		process.exit(1);
+	}
+	const remaining = args.filter((_, i) => i !== outputIndex && i !== outputIndex + 1);
+	manifestPath = remaining[0];
+} else {
+	console.error("Error: --output is required.");
+	process.exit(1);
+}
+
+if (!manifestPath) {
+	console.error("Error: manifest file path is required.");
+	process.exit(1);
+}
+
+try {
+	const result = await generateDocsFromFile(manifestPath);
+	const written = await writeDocsToDirectory(result, outputDir);
+	console.log(`\u2713 Generated ${written.length} documentation pages to ${resolve(outputDir)}`);
+	for (const path of written) {
+		console.log(`  ${path}`);
+	}
+} catch (e) {
+	const message = e instanceof Error ? e.message : String(e);
+	console.error(`Error: ${message}`);
+	process.exit(1);
+}

--- a/tools/docgen/src/index.ts
+++ b/tools/docgen/src/index.ts
@@ -1,0 +1,455 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { resolve, join } from "node:path";
+
+interface Manifest {
+	xript: string;
+	name: string;
+	version?: string;
+	title?: string;
+	description?: string;
+	bindings?: Record<string, Binding>;
+	capabilities?: Record<string, Capability>;
+	types?: Record<string, TypeDefinition>;
+}
+
+type Binding = FunctionBinding | NamespaceBinding;
+
+interface FunctionBinding {
+	description: string;
+	params?: Parameter[];
+	returns?: TypeRef;
+	async?: boolean;
+	capability?: string;
+	examples?: Example[];
+	deprecated?: string;
+}
+
+interface NamespaceBinding {
+	description: string;
+	members: Record<string, Binding>;
+}
+
+interface Parameter {
+	name: string;
+	type: TypeRef;
+	description?: string;
+	default?: unknown;
+	required?: boolean;
+}
+
+type TypeRef = string | ComplexTypeRef;
+
+interface ComplexTypeRef {
+	array?: TypeRef;
+	union?: TypeRef[];
+	map?: TypeRef;
+	optional?: TypeRef;
+}
+
+interface Capability {
+	description: string;
+	risk?: string;
+}
+
+interface TypeDefinition {
+	description: string;
+	fields?: Record<string, FieldDefinition>;
+	values?: string[];
+}
+
+interface FieldDefinition {
+	type: TypeRef;
+	description?: string;
+	optional?: boolean;
+}
+
+interface Example {
+	title?: string;
+	code: string;
+	description?: string;
+}
+
+export interface DocgenResult {
+	pages: DocPage[];
+}
+
+export interface DocPage {
+	slug: string;
+	title: string;
+	content: string;
+}
+
+function isNamespace(binding: Binding): binding is NamespaceBinding {
+	return "members" in binding;
+}
+
+function formatTypeRef(ref: TypeRef): string {
+	if (typeof ref === "string") {
+		const primitives = ["string", "number", "boolean", "void", "null"];
+		if (primitives.includes(ref)) return `\`${ref}\``;
+		if (ref.endsWith("[]")) return `\`${ref.slice(0, -2)}\`[]`;
+		return `\`${ref}\``;
+	}
+	if (ref.array !== undefined) return `${formatTypeRef(ref.array)}[]`;
+	if (ref.union) return ref.union.map(formatTypeRef).join(" \\| ");
+	if (ref.map !== undefined) return `Record<string, ${formatTypeRef(ref.map)}>`;
+	if (ref.optional !== undefined) return `${formatTypeRef(ref.optional)} \\| undefined`;
+	return "`unknown`";
+}
+
+function typeRefToCode(ref: TypeRef): string {
+	if (typeof ref === "string") {
+		if (ref.endsWith("[]")) return `${ref.slice(0, -2)}[]`;
+		return ref;
+	}
+	if (ref.array !== undefined) return `${typeRefToCode(ref.array)}[]`;
+	if (ref.union) return ref.union.map(typeRefToCode).join(" | ");
+	if (ref.map !== undefined) return `Record<string, ${typeRefToCode(ref.map)}>`;
+	if (ref.optional !== undefined) return `${typeRefToCode(ref.optional)} | undefined`;
+	return "unknown";
+}
+
+function isOptionalParam(param: Parameter): boolean {
+	return param.default !== undefined || param.required === false;
+}
+
+function generateIndexPage(manifest: Manifest): DocPage {
+	const lines: string[] = [];
+	const displayName = manifest.title || manifest.name;
+
+	lines.push(`# ${displayName} API Reference`);
+	lines.push("");
+	if (manifest.description) {
+		lines.push(manifest.description);
+		lines.push("");
+	}
+	if (manifest.version) {
+		lines.push(`**API Version:** ${manifest.version}`);
+		lines.push("");
+	}
+
+	if (manifest.bindings) {
+		lines.push("## API Surface");
+		lines.push("");
+
+		const topLevel: string[] = [];
+		const namespaces: string[] = [];
+
+		for (const [name, binding] of Object.entries(manifest.bindings)) {
+			if (isNamespace(binding)) {
+				namespaces.push(name);
+			} else {
+				topLevel.push(name);
+			}
+		}
+
+		if (topLevel.length > 0) {
+			lines.push("### Global Functions");
+			lines.push("");
+			for (const name of topLevel) {
+				const binding = manifest.bindings[name] as FunctionBinding;
+				lines.push(`- [\`${name}()\`](./bindings/${name}.md) — ${binding.description}`);
+			}
+			lines.push("");
+		}
+
+		if (namespaces.length > 0) {
+			lines.push("### Namespaces");
+			lines.push("");
+			for (const name of namespaces) {
+				const binding = manifest.bindings[name] as NamespaceBinding;
+				const memberCount = Object.keys(binding.members).length;
+				lines.push(
+					`- [\`${name}\`](./bindings/${name}.md) — ${binding.description} (${memberCount} ${memberCount === 1 ? "function" : "functions"})`,
+				);
+			}
+			lines.push("");
+		}
+	}
+
+	if (manifest.types) {
+		lines.push("## Types");
+		lines.push("");
+		for (const [name, def] of Object.entries(manifest.types)) {
+			const kind = def.values ? "enum" : "interface";
+			lines.push(`- [\`${name}\`](./types/${name}.md) — ${def.description} *(${kind})*`);
+		}
+		lines.push("");
+	}
+
+	if (manifest.capabilities) {
+		lines.push("## Capabilities");
+		lines.push("");
+		lines.push("| Capability | Description | Risk |");
+		lines.push("|------------|-------------|------|");
+		for (const [name, cap] of Object.entries(manifest.capabilities)) {
+			const risk = cap.risk || "low";
+			lines.push(`| \`${name}\` | ${cap.description} | ${risk} |`);
+		}
+		lines.push("");
+	}
+
+	return { slug: "index", title: `${displayName} API Reference`, content: lines.join("\n") };
+}
+
+function generateFunctionPage(name: string, binding: FunctionBinding): DocPage {
+	const lines: string[] = [];
+
+	lines.push(`# ${name}()`);
+	lines.push("");
+	if (binding.deprecated) {
+		lines.push(`> **Deprecated:** ${binding.deprecated}`);
+		lines.push("");
+	}
+	lines.push(binding.description);
+	lines.push("");
+
+	const params = binding.params || [];
+	const paramStr = params
+		.map((p) => {
+			const opt = isOptionalParam(p) ? "?" : "";
+			return `${p.name}${opt}: ${typeRefToCode(p.type)}`;
+		})
+		.join(", ");
+	let returnType = binding.returns ? typeRefToCode(binding.returns) : "void";
+	if (binding.async) returnType = `Promise<${returnType}>`;
+
+	lines.push("## Signature");
+	lines.push("");
+	lines.push("```typescript");
+	lines.push(`function ${name}(${paramStr}): ${returnType}`);
+	lines.push("```");
+	lines.push("");
+
+	if (params.length > 0) {
+		lines.push("## Parameters");
+		lines.push("");
+		lines.push("| Name | Type | Required | Description |");
+		lines.push("|------|------|----------|-------------|");
+		for (const p of params) {
+			const req = isOptionalParam(p) ? "No" : "Yes";
+			const desc = p.description || "";
+			const defaultNote = p.default !== undefined ? ` (default: \`${JSON.stringify(p.default)}\`)` : "";
+			lines.push(`| \`${p.name}\` | ${formatTypeRef(p.type)} | ${req} | ${desc}${defaultNote} |`);
+		}
+		lines.push("");
+	}
+
+	if (binding.returns) {
+		lines.push("## Returns");
+		lines.push("");
+		lines.push(`${formatTypeRef(binding.returns)}${binding.async ? " (async)" : ""}`);
+		lines.push("");
+	}
+
+	if (binding.capability) {
+		lines.push("## Requires Capability");
+		lines.push("");
+		lines.push(`This function requires the \`${binding.capability}\` capability.`);
+		lines.push("");
+	}
+
+	if (binding.examples && binding.examples.length > 0) {
+		lines.push("## Examples");
+		lines.push("");
+		for (const example of binding.examples) {
+			if (example.title) {
+				lines.push(`### ${example.title}`);
+				lines.push("");
+			}
+			if (example.description) {
+				lines.push(example.description);
+				lines.push("");
+			}
+			lines.push("```javascript");
+			lines.push(example.code);
+			lines.push("```");
+			lines.push("");
+		}
+	}
+
+	return { slug: `bindings/${name}`, title: `${name}()`, content: lines.join("\n") };
+}
+
+function generateNamespacePage(name: string, binding: NamespaceBinding, manifest: Manifest): DocPage {
+	const lines: string[] = [];
+
+	lines.push(`# ${name}`);
+	lines.push("");
+	lines.push(binding.description);
+	lines.push("");
+
+	lines.push("## Functions");
+	lines.push("");
+
+	for (const [memberName, memberBinding] of Object.entries(binding.members)) {
+		if (isNamespace(memberBinding)) continue;
+		const fn = memberBinding as FunctionBinding;
+		const params = fn.params || [];
+		const paramStr = params
+			.map((p) => {
+				const opt = isOptionalParam(p) ? "?" : "";
+				return `${p.name}${opt}: ${typeRefToCode(p.type)}`;
+			})
+			.join(", ");
+		let returnType = fn.returns ? typeRefToCode(fn.returns) : "void";
+		if (fn.async) returnType = `Promise<${returnType}>`;
+
+		lines.push(`### ${name}.${memberName}()`);
+		lines.push("");
+		if (fn.deprecated) {
+			lines.push(`> **Deprecated:** ${fn.deprecated}`);
+			lines.push("");
+		}
+		lines.push(fn.description);
+		lines.push("");
+		lines.push("```typescript");
+		lines.push(`function ${memberName}(${paramStr}): ${returnType}`);
+		lines.push("```");
+		lines.push("");
+
+		if (params.length > 0) {
+			lines.push("**Parameters:**");
+			lines.push("");
+			lines.push("| Name | Type | Required | Description |");
+			lines.push("|------|------|----------|-------------|");
+			for (const p of params) {
+				const req = isOptionalParam(p) ? "No" : "Yes";
+				const desc = p.description || "";
+				const defaultNote = p.default !== undefined ? ` (default: \`${JSON.stringify(p.default)}\`)` : "";
+				lines.push(`| \`${p.name}\` | ${formatTypeRef(p.type)} | ${req} | ${desc}${defaultNote} |`);
+			}
+			lines.push("");
+		}
+
+		if (fn.returns) {
+			lines.push(`**Returns:** ${formatTypeRef(fn.returns)}${fn.async ? " (async)" : ""}`);
+			lines.push("");
+		}
+
+		if (fn.capability) {
+			lines.push(`**Requires capability:** \`${fn.capability}\``);
+			lines.push("");
+		}
+
+		if (fn.examples && fn.examples.length > 0) {
+			for (const example of fn.examples) {
+				if (example.title) {
+					lines.push(`**Example: ${example.title}**`);
+					lines.push("");
+				}
+				if (example.description) {
+					lines.push(example.description);
+					lines.push("");
+				}
+				lines.push("```javascript");
+				lines.push(example.code);
+				lines.push("```");
+				lines.push("");
+			}
+		}
+	}
+
+	return { slug: `bindings/${name}`, title: name, content: lines.join("\n") };
+}
+
+function generateTypePage(name: string, def: TypeDefinition): DocPage {
+	const lines: string[] = [];
+
+	lines.push(`# ${name}`);
+	lines.push("");
+	lines.push(def.description);
+	lines.push("");
+
+	if (def.values) {
+		lines.push("## Values");
+		lines.push("");
+		lines.push(`\`${name}\` is a string enum with the following values:`);
+		lines.push("");
+		for (const value of def.values) {
+			lines.push(`- \`"${value}"\``);
+		}
+		lines.push("");
+		lines.push("## TypeScript");
+		lines.push("");
+		lines.push("```typescript");
+		lines.push(`type ${name} = ${def.values.map((v) => `"${v}"`).join(" | ")};`);
+		lines.push("```");
+		lines.push("");
+	} else if (def.fields) {
+		lines.push("## Fields");
+		lines.push("");
+		lines.push("| Field | Type | Required | Description |");
+		lines.push("|-------|------|----------|-------------|");
+		for (const [fieldName, field] of Object.entries(def.fields)) {
+			const req = field.optional ? "No" : "Yes";
+			const desc = field.description || "";
+			lines.push(`| \`${fieldName}\` | ${formatTypeRef(field.type)} | ${req} | ${desc} |`);
+		}
+		lines.push("");
+		lines.push("## TypeScript");
+		lines.push("");
+		lines.push("```typescript");
+		lines.push(`interface ${name} {`);
+		for (const [fieldName, field] of Object.entries(def.fields)) {
+			const opt = field.optional ? "?" : "";
+			lines.push(`  ${fieldName}${opt}: ${typeRefToCode(field.type)};`);
+		}
+		lines.push("}");
+		lines.push("```");
+		lines.push("");
+	}
+
+	return { slug: `types/${name}`, title: name, content: lines.join("\n") };
+}
+
+export function generateDocs(manifest: unknown): DocgenResult {
+	const m = manifest as Manifest;
+	const pages: DocPage[] = [];
+
+	pages.push(generateIndexPage(m));
+
+	if (m.bindings) {
+		for (const [name, binding] of Object.entries(m.bindings)) {
+			if (isNamespace(binding)) {
+				pages.push(generateNamespacePage(name, binding, m));
+			} else {
+				pages.push(generateFunctionPage(name, binding));
+			}
+		}
+	}
+
+	if (m.types) {
+		for (const [name, def] of Object.entries(m.types)) {
+			pages.push(generateTypePage(name, def));
+		}
+	}
+
+	return { pages };
+}
+
+export async function generateDocsFromFile(filePath: string): Promise<DocgenResult> {
+	const absolutePath = resolve(filePath);
+	const raw = await readFile(absolutePath, "utf-8");
+	const manifest = JSON.parse(raw) as unknown;
+	return generateDocs(manifest);
+}
+
+export async function writeDocsToDirectory(result: DocgenResult, outputDir: string): Promise<string[]> {
+	const absoluteDir = resolve(outputDir);
+	await mkdir(absoluteDir, { recursive: true });
+	const writtenPaths: string[] = [];
+
+	for (const page of result.pages) {
+		const filePath = join(absoluteDir, `${page.slug}.md`);
+		const segments = page.slug.split("/");
+		if (segments.length > 1) {
+			const dir = join(absoluteDir, ...segments.slice(0, -1));
+			await mkdir(dir, { recursive: true });
+		}
+		await writeFile(filePath, page.content, "utf-8");
+		writtenPaths.push(filePath);
+	}
+
+	return writtenPaths;
+}

--- a/tools/docgen/test/docgen.test.js
+++ b/tools/docgen/test/docgen.test.js
@@ -1,0 +1,259 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { generateDocs, generateDocsFromFile } from "../dist/index.js";
+
+describe("generateDocs", () => {
+	it("generates an index page with manifest metadata", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test-app",
+			title: "Test Application",
+			version: "1.0.0",
+			description: "A test application.",
+		});
+		const index = result.pages.find((p) => p.slug === "index");
+		assert.ok(index);
+		assert.ok(index.content.includes("# Test Application API Reference"));
+		assert.ok(index.content.includes("A test application."));
+		assert.ok(index.content.includes("**API Version:** 1.0.0"));
+	});
+
+	it("generates an index page with function and namespace listings", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test",
+			bindings: {
+				log: { description: "Logs a message." },
+				player: { description: "Player functions.", members: { getHealth: { description: "Gets health.", returns: "number" } } },
+			},
+		});
+		const index = result.pages.find((p) => p.slug === "index");
+		assert.ok(index);
+		assert.ok(index.content.includes("`log()`"));
+		assert.ok(index.content.includes("`player`"));
+		assert.ok(index.content.includes("1 function"));
+	});
+
+	it("generates function binding pages", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test",
+			bindings: {
+				log: {
+					description: "Logs a message.",
+					params: [{ name: "message", type: "string", description: "The message." }],
+				},
+			},
+		});
+		const page = result.pages.find((p) => p.slug === "bindings/log");
+		assert.ok(page);
+		assert.ok(page.content.includes("# log()"));
+		assert.ok(page.content.includes("function log(message: string): void"));
+		assert.ok(page.content.includes("| `message` |"));
+	});
+
+	it("generates namespace binding pages", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test",
+			bindings: {
+				player: {
+					description: "Player functions.",
+					members: {
+						getHealth: { description: "Returns health.", returns: "number" },
+						setHealth: {
+							description: "Sets health.",
+							params: [{ name: "value", type: "number" }],
+							capability: "modify-player",
+						},
+					},
+				},
+			},
+		});
+		const page = result.pages.find((p) => p.slug === "bindings/player");
+		assert.ok(page);
+		assert.ok(page.content.includes("# player"));
+		assert.ok(page.content.includes("### player.getHealth()"));
+		assert.ok(page.content.includes("### player.setHealth()"));
+		assert.ok(page.content.includes("`modify-player`"));
+	});
+
+	it("generates type pages for interfaces", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test",
+			types: {
+				Position: {
+					description: "A 2D position.",
+					fields: {
+						x: { type: "number", description: "Horizontal." },
+						y: { type: "number", description: "Vertical." },
+					},
+				},
+			},
+		});
+		const page = result.pages.find((p) => p.slug === "types/Position");
+		assert.ok(page);
+		assert.ok(page.content.includes("# Position"));
+		assert.ok(page.content.includes("A 2D position."));
+		assert.ok(page.content.includes("| `x` |"));
+		assert.ok(page.content.includes("interface Position {"));
+	});
+
+	it("generates type pages for enums", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test",
+			types: {
+				Direction: {
+					description: "A direction.",
+					values: ["north", "south", "east", "west"],
+				},
+			},
+		});
+		const page = result.pages.find((p) => p.slug === "types/Direction");
+		assert.ok(page);
+		assert.ok(page.content.includes("# Direction"));
+		assert.ok(page.content.includes('`"north"`'));
+		assert.ok(page.content.includes('type Direction = "north" | "south" | "east" | "west"'));
+	});
+
+	it("includes capability table in index", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test",
+			capabilities: {
+				"modify-player": { description: "Modify player.", risk: "medium" },
+				storage: { description: "Use storage.", risk: "low" },
+			},
+		});
+		const index = result.pages.find((p) => p.slug === "index");
+		assert.ok(index);
+		assert.ok(index.content.includes("| `modify-player` |"));
+		assert.ok(index.content.includes("| medium |"));
+		assert.ok(index.content.includes("| `storage` |"));
+	});
+
+	it("handles deprecated functions", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test",
+			bindings: {
+				getHP: {
+					description: "Gets health.",
+					returns: "number",
+					deprecated: "Use getHealth() instead.",
+				},
+			},
+		});
+		const page = result.pages.find((p) => p.slug === "bindings/getHP");
+		assert.ok(page);
+		assert.ok(page.content.includes("**Deprecated:** Use getHealth() instead."));
+	});
+
+	it("handles async functions", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test",
+			bindings: {
+				fetch: {
+					description: "Fetches data.",
+					returns: "string",
+					async: true,
+				},
+			},
+		});
+		const page = result.pages.find((p) => p.slug === "bindings/fetch");
+		assert.ok(page);
+		assert.ok(page.content.includes("Promise<string>"));
+		assert.ok(page.content.includes("(async)"));
+	});
+
+	it("handles optional parameters", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test",
+			bindings: {
+				greet: {
+					description: "Greets.",
+					params: [
+						{ name: "name", type: "string" },
+						{ name: "loud", type: "boolean", default: false },
+					],
+					returns: "string",
+				},
+			},
+		});
+		const page = result.pages.find((p) => p.slug === "bindings/greet");
+		assert.ok(page);
+		assert.ok(page.content.includes("loud?: boolean"));
+		assert.ok(page.content.includes("| No |"));
+		assert.ok(page.content.includes("(default: `false`)"));
+	});
+
+	it("includes examples in function pages", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test",
+			bindings: {
+				heal: {
+					description: "Heals.",
+					examples: [
+						{ title: "Full heal", code: "heal(100);", description: "Heals to full." },
+					],
+				},
+			},
+		});
+		const page = result.pages.find((p) => p.slug === "bindings/heal");
+		assert.ok(page);
+		assert.ok(page.content.includes("### Full heal"));
+		assert.ok(page.content.includes("heal(100);"));
+		assert.ok(page.content.includes("Heals to full."));
+	});
+
+	it("handles optional type fields", () => {
+		const result = generateDocs({
+			xript: "0.1",
+			name: "test",
+			types: {
+				Item: {
+					description: "An item.",
+					fields: {
+						id: { type: "string" },
+						damage: { type: "number", optional: true },
+					},
+				},
+			},
+		});
+		const page = result.pages.find((p) => p.slug === "types/Item");
+		assert.ok(page);
+		assert.ok(page.content.includes("damage?: number;"));
+		assert.ok(page.content.includes("| No |"));
+	});
+
+	it("generates full docs for the dungeon-crawler example", async () => {
+		const result = await generateDocsFromFile("../../examples/game-mod-system.json");
+		assert.equal(result.pages.length, 10);
+
+		const slugs = result.pages.map((p) => p.slug).sort();
+		assert.deepEqual(slugs, [
+			"bindings/data",
+			"bindings/log",
+			"bindings/player",
+			"bindings/world",
+			"index",
+			"types/Enemy",
+			"types/EnemyType",
+			"types/Item",
+			"types/ItemType",
+			"types/Position",
+		]);
+	});
+
+	it("produces minimal output for empty manifest", () => {
+		const result = generateDocs({ xript: "0.1", name: "minimal" });
+		assert.equal(result.pages.length, 1);
+		assert.equal(result.pages[0].slug, "index");
+		assert.ok(!result.pages[0].content.includes("## API Surface"));
+	});
+});

--- a/tools/docgen/tsconfig.json
+++ b/tools/docgen/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"declaration": true,
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true
+	},
+	"include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

- Built `@xript/docgen` package that generates structured markdown documentation from xript manifests
- Produces: index page (API overview, types, capabilities table), per-function pages, per-namespace pages, per-type pages (interfaces and enums)
- Each page includes TypeScript signatures, parameter tables, return types, examples, capability annotations, and deprecation notices
- CLI (`xript-docgen`) writes pages to a directory via `--output`
- Generates 10 pages from the dungeon-crawler example manifest
- 14 passing tests covering all page types, edge cases, and the full example manifest

## Test plan

- [x] All 14 tests pass (`npm test` in `tools/docgen/`)
- [x] TypeScript builds cleanly (`tsc`)
- [x] CLI produces correct output for `examples/game-mod-system.json` (10 pages)
- [x] Generated markdown is well-structured with proper headings, tables, and code blocks

Closes #9