### PR TITLE
build the reference JavaScript runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,15 @@ xript/
 ## Development Commands
 
 ```sh
-npm install              # install all workspace dependencies
-npm run docs:dev         # run the docs site locally on port 4351
-npm run docs:build       # build the docs site for production
+npm install                            # install all workspace dependencies
+npm run docs:dev                       # run the docs site locally on port 4351
+npm run docs:build                     # build the docs site for production
+
+# tools (run from repo root after npm install)
+npx xript-validate <manifest.json>     # validate a manifest against the spec schema
+npx xript-typegen <manifest.json>      # generate TypeScript definitions (stdout)
+npx xript-typegen <m.json> -o out.d.ts # generate TypeScript definitions (file)
+npx xript-docgen <m.json> -o docs/     # generate markdown documentation
 ```
 
 ## Conventions
@@ -43,7 +49,11 @@ npm run docs:build       # build the docs site for production
 
 ## Current State
 
-The project is in its earliest stage. The vision document and docs site exist. The specification, runtimes, tools, and examples are all planned but not yet implemented. Check the GitHub issues and milestones for the current roadmap.
+- **Spec v0.1** is complete: manifest schema (JSON Schema draft 2020-12), capability model, binding conventions, and security guarantees are all documented in `spec/`
+- **Toolchain** is complete: manifest validator (`@xript/manifest-validator`), type generator (`@xript/typegen`), and doc generator (`@xript/docgen`) are all built and tested in `tools/`
+- **Docs site** is live at xript.dev with Starlight, covering the vision and all spec documents
+- **Reference runtime** (`runtimes/js/`) is the current focus -- the first implementation of the spec using Node.js `vm` module for sandboxed execution
+- Check GitHub issues and milestones for the current roadmap
 
 ## Key Design Decisions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1846,6 +1846,10 @@
 			"resolved": "tools/manifest-validator",
 			"link": true
 		},
+		"node_modules/@xript/runtime-js": {
+			"resolved": "runtimes/js",
+			"link": true
+		},
 		"node_modules/@xript/typegen": {
 			"resolved": "tools/typegen",
 			"link": true
@@ -6485,6 +6489,32 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"runtimes/js": {
+			"name": "@xript/runtime-js",
+			"version": "0.1.0",
+			"license": "MIT",
+			"devDependencies": {
+				"@types/node": "^22.0.0",
+				"typescript": "^5.7.0"
+			}
+		},
+		"runtimes/js/node_modules/@types/node": {
+			"version": "22.19.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.10.tgz",
+			"integrity": "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"runtimes/js/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"tools/docgen": {
 			"name": "@xript/docgen",

--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -2,9 +2,12 @@
 
 Language-specific implementations of the xript runtime.
 
+## Available Runtimes
+
+- **js/** (`@xript/runtime-js`) — reference JavaScript runtime using Node.js `vm` module for sandboxed execution
+
 ## Planned Runtimes
 
-- **js/** — JavaScript/TypeScript (likely QuickJS-based)
 - **rust/** — Rust
 - **go/** — Go
 - **csharp/** — C# / .NET

--- a/runtimes/js/package.json
+++ b/runtimes/js/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@xript/runtime-js",
+	"version": "0.1.0",
+	"description": "Reference JavaScript runtime for xript — sandboxed script execution with manifest-driven bindings.",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"scripts": {
+		"build": "tsc",
+		"test": "node --test test/*.test.js",
+		"prepublishOnly": "npm run build"
+	},
+	"keywords": ["xript", "runtime", "sandbox", "scripting", "modding"],
+	"license": "MIT",
+	"devDependencies": {
+		"typescript": "^5.7.0",
+		"@types/node": "^22.0.0"
+	}
+}

--- a/runtimes/js/src/errors.ts
+++ b/runtimes/js/src/errors.ts
@@ -1,0 +1,33 @@
+export class BindingError extends Error {
+	public readonly binding: string;
+
+	constructor(binding: string, message: string) {
+		super(`${binding}: ${message}`);
+		this.name = "BindingError";
+		this.binding = binding;
+	}
+}
+
+export class CapabilityDeniedError extends Error {
+	public readonly capability: string;
+	public readonly binding: string;
+
+	constructor(binding: string, capability: string) {
+		super(
+			`calling "${binding}" requires the "${capability}" capability, which has not been granted to this script.`,
+		);
+		this.name = "CapabilityDeniedError";
+		this.capability = capability;
+		this.binding = binding;
+	}
+}
+
+export class ExecutionLimitError extends Error {
+	public readonly limit: string;
+
+	constructor(limit: string, message: string) {
+		super(message);
+		this.name = "ExecutionLimitError";
+		this.limit = limit;
+	}
+}

--- a/runtimes/js/src/index.ts
+++ b/runtimes/js/src/index.ts
@@ -1,0 +1,66 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { createSandbox, type HostBindings, type HostFunction, type SandboxOptions, type ExecutionResult } from "./sandbox.js";
+
+export { BindingError, CapabilityDeniedError, ExecutionLimitError } from "./errors.js";
+export type { HostBindings, HostFunction, ExecutionResult } from "./sandbox.js";
+
+interface Manifest {
+	xript: string;
+	name: string;
+	version?: string;
+	bindings?: Record<string, unknown>;
+	capabilities?: Record<string, unknown>;
+	limits?: {
+		timeout_ms?: number;
+		memory_mb?: number;
+		max_stack_depth?: number;
+	};
+}
+
+export interface RuntimeOptions {
+	hostBindings: HostBindings;
+	capabilities?: string[];
+	console?: {
+		log: (...args: unknown[]) => void;
+		warn: (...args: unknown[]) => void;
+		error: (...args: unknown[]) => void;
+	};
+}
+
+export interface XriptRuntime {
+	readonly manifest: Manifest;
+	execute(code: string): ExecutionResult;
+	executeAsync(code: string): Promise<ExecutionResult>;
+}
+
+export function createRuntime(manifest: unknown, options: RuntimeOptions): XriptRuntime {
+	const m = manifest as Manifest;
+
+	if (!m.xript || !m.name) {
+		throw new Error("Invalid manifest: 'xript' and 'name' are required fields.");
+	}
+
+	const sandbox = createSandbox({
+		manifest: m as SandboxOptions["manifest"],
+		hostBindings: options.hostBindings,
+		capabilities: options.capabilities,
+		console: options.console,
+	});
+
+	return {
+		manifest: m,
+		execute: sandbox.execute,
+		executeAsync: sandbox.executeAsync,
+	};
+}
+
+export async function createRuntimeFromFile(
+	manifestPath: string,
+	options: RuntimeOptions,
+): Promise<XriptRuntime> {
+	const absolutePath = resolve(manifestPath);
+	const raw = await readFile(absolutePath, "utf-8");
+	const manifest = JSON.parse(raw) as unknown;
+	return createRuntime(manifest, options);
+}

--- a/runtimes/js/src/sandbox.ts
+++ b/runtimes/js/src/sandbox.ts
@@ -1,0 +1,261 @@
+import vm from "node:vm";
+import { BindingError, CapabilityDeniedError } from "./errors.js";
+
+interface Manifest {
+	xript: string;
+	name: string;
+	version?: string;
+	bindings?: Record<string, Binding>;
+	capabilities?: Record<string, CapabilityDef>;
+	limits?: ExecutionLimits;
+}
+
+type Binding = FunctionBinding | NamespaceBinding;
+
+interface FunctionBinding {
+	description: string;
+	params?: Parameter[];
+	returns?: unknown;
+	async?: boolean;
+	capability?: string;
+	deprecated?: string;
+}
+
+interface NamespaceBinding {
+	description: string;
+	members: Record<string, Binding>;
+}
+
+interface Parameter {
+	name: string;
+	type: unknown;
+	default?: unknown;
+	required?: boolean;
+}
+
+interface CapabilityDef {
+	description: string;
+	risk?: string;
+}
+
+interface ExecutionLimits {
+	timeout_ms?: number;
+	memory_mb?: number;
+	max_stack_depth?: number;
+}
+
+export type HostFunction = (...args: unknown[]) => unknown;
+export type HostBindings = Record<string, HostFunction | Record<string, HostFunction>>;
+
+export interface SandboxOptions {
+	manifest: Manifest;
+	hostBindings: HostBindings;
+	capabilities?: string[];
+	console?: {
+		log: (...args: unknown[]) => void;
+		warn: (...args: unknown[]) => void;
+		error: (...args: unknown[]) => void;
+	};
+}
+
+export interface ExecutionResult {
+	value: unknown;
+	duration_ms: number;
+}
+
+function isNamespace(binding: Binding): binding is NamespaceBinding {
+	return "members" in binding;
+}
+
+function buildSandboxGlobal(options: SandboxOptions): Record<string, unknown> {
+	const { manifest, hostBindings, capabilities = [] } = options;
+	const grantedCapabilities = new Set(capabilities);
+
+	const sandboxConsole = options.console || {
+		log: () => {},
+		warn: () => {},
+		error: () => {},
+	};
+
+	const globals: Record<string, unknown> = {};
+
+	globals.console = {
+		log: (...args: unknown[]) => sandboxConsole.log(...args),
+		warn: (...args: unknown[]) => sandboxConsole.warn(...args),
+		error: (...args: unknown[]) => sandboxConsole.error(...args),
+	};
+
+	globals.JSON = { parse: JSON.parse, stringify: JSON.stringify };
+	globals.Math = Math;
+	globals.Date = Date;
+	globals.Number = Number;
+	globals.String = String;
+	globals.Boolean = Boolean;
+	globals.Array = Array;
+	globals.Object = Object;
+	globals.Map = Map;
+	globals.Set = Set;
+	globals.WeakMap = WeakMap;
+	globals.WeakSet = WeakSet;
+	globals.Promise = Promise;
+	globals.Error = Error;
+	globals.TypeError = TypeError;
+	globals.RangeError = RangeError;
+	globals.SyntaxError = SyntaxError;
+	globals.ReferenceError = ReferenceError;
+	globals.RegExp = RegExp;
+	globals.Symbol = Symbol;
+	globals.ArrayBuffer = ArrayBuffer;
+	globals.DataView = DataView;
+	globals.Int8Array = Int8Array;
+	globals.Uint8Array = Uint8Array;
+	globals.Int16Array = Int16Array;
+	globals.Uint16Array = Uint16Array;
+	globals.Int32Array = Int32Array;
+	globals.Uint32Array = Uint32Array;
+	globals.Float32Array = Float32Array;
+	globals.Float64Array = Float64Array;
+	globals.BigInt64Array = BigInt64Array;
+	globals.BigUint64Array = BigUint64Array;
+	globals.BigInt = BigInt;
+	globals.Proxy = Proxy;
+	globals.Reflect = Reflect;
+
+	globals.isNaN = isNaN;
+	globals.isFinite = isFinite;
+	globals.parseInt = parseInt;
+	globals.parseFloat = parseFloat;
+	globals.undefined = undefined;
+	globals.NaN = NaN;
+	globals.Infinity = Infinity;
+
+	globals.BindingError = BindingError;
+	globals.CapabilityDeniedError = CapabilityDeniedError;
+
+	globals.eval = () => {
+		throw new TypeError("eval() is not permitted. Dynamic code generation is disabled in xript.");
+	};
+	globals.Function = new Proxy(Function, {
+		construct() {
+			throw new TypeError(
+				"new Function() is not permitted. Dynamic code generation is disabled in xript.",
+			);
+		},
+		apply() {
+			throw new TypeError(
+				"Function() is not permitted. Dynamic code generation is disabled in xript.",
+			);
+		},
+	});
+
+	if (manifest.bindings) {
+		for (const [name, binding] of Object.entries(manifest.bindings)) {
+			if (isNamespace(binding)) {
+				globals[name] = buildNamespace(
+					name,
+					binding,
+					hostBindings[name] as Record<string, HostFunction> | undefined,
+					grantedCapabilities,
+				);
+			} else {
+				globals[name] = buildFunction(
+					name,
+					binding,
+					hostBindings[name] as HostFunction | undefined,
+					grantedCapabilities,
+				);
+			}
+		}
+	}
+
+	return globals;
+}
+
+function buildFunction(
+	qualifiedName: string,
+	binding: FunctionBinding,
+	hostFn: HostFunction | undefined,
+	grantedCapabilities: Set<string>,
+): HostFunction {
+	return (...args: unknown[]) => {
+		if (binding.capability && !grantedCapabilities.has(binding.capability)) {
+			throw new CapabilityDeniedError(qualifiedName, binding.capability);
+		}
+
+		if (!hostFn) {
+			throw new BindingError(qualifiedName, "no host implementation provided");
+		}
+
+		try {
+			return hostFn(...args);
+		} catch (e) {
+			if (e instanceof CapabilityDeniedError || e instanceof BindingError) throw e;
+			const message = e instanceof Error ? e.message : String(e);
+			throw new BindingError(qualifiedName, message);
+		}
+	};
+}
+
+function buildNamespace(
+	namespaceName: string,
+	binding: NamespaceBinding,
+	hostNs: Record<string, HostFunction> | undefined,
+	grantedCapabilities: Set<string>,
+): Record<string, unknown> {
+	const ns: Record<string, unknown> = {};
+
+	for (const [memberName, memberBinding] of Object.entries(binding.members)) {
+		const qualifiedName = `${namespaceName}.${memberName}`;
+		if (isNamespace(memberBinding)) {
+			const nestedHostNs = hostNs
+				? (hostNs[memberName] as unknown as Record<string, HostFunction>)
+				: undefined;
+			ns[memberName] = buildNamespace(qualifiedName, memberBinding, nestedHostNs, grantedCapabilities);
+		} else {
+			const hostFn = hostNs ? hostNs[memberName] : undefined;
+			ns[memberName] = buildFunction(qualifiedName, memberBinding, hostFn, grantedCapabilities);
+		}
+	}
+
+	return Object.freeze(ns);
+}
+
+export function createSandbox(options: SandboxOptions): {
+	execute: (code: string) => ExecutionResult;
+	executeAsync: (code: string) => Promise<ExecutionResult>;
+} {
+	const { manifest } = options;
+	const limits = manifest.limits || {};
+	const timeoutMs = limits.timeout_ms ?? 5000;
+
+	const sandboxGlobals = buildSandboxGlobal(options);
+
+	const context = vm.createContext(sandboxGlobals, {
+		codeGeneration: {
+			strings: false,
+			wasm: false,
+		},
+	});
+
+	sandboxGlobals.globalThis = context;
+
+	function execute(code: string): ExecutionResult {
+		const start = performance.now();
+		const script = new vm.Script(code, { filename: "xript-script.js" });
+		const value = script.runInContext(context, { timeout: timeoutMs });
+		const duration_ms = performance.now() - start;
+		return { value, duration_ms };
+	}
+
+	async function executeAsync(code: string): Promise<ExecutionResult> {
+		const start = performance.now();
+		const wrappedCode = `(async () => { ${code} })()`;
+		const script = new vm.Script(wrappedCode, { filename: "xript-script.js" });
+		const promise = script.runInContext(context, { timeout: timeoutMs });
+		const value = await promise;
+		const duration_ms = performance.now() - start;
+		return { value, duration_ms };
+	}
+
+	return { execute, executeAsync };
+}

--- a/runtimes/js/test/runtime.test.js
+++ b/runtimes/js/test/runtime.test.js
@@ -1,0 +1,417 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createRuntime, createRuntimeFromFile } from "../dist/index.js";
+
+const minimalManifest = {
+	xript: "0.1",
+	name: "test-app",
+};
+
+describe("createRuntime", () => {
+	it("creates a runtime from a valid manifest", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		assert.ok(runtime);
+		assert.equal(runtime.manifest.name, "test-app");
+	});
+
+	it("rejects invalid manifests", () => {
+		assert.throws(() => createRuntime({}, { hostBindings: {} }), /Invalid manifest/);
+		assert.throws(() => createRuntime({ xript: "0.1" }, { hostBindings: {} }), /Invalid manifest/);
+	});
+});
+
+describe("basic script execution", () => {
+	it("executes simple expressions", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		const result = runtime.execute("2 + 2");
+		assert.equal(result.value, 4);
+		assert.ok(result.duration_ms >= 0);
+	});
+
+	it("executes multi-line scripts", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		const result = runtime.execute("const a = 10; const b = 20; a + b;");
+		assert.equal(result.value, 30);
+	});
+
+	it("supports standard JavaScript built-ins", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+
+		assert.equal(runtime.execute("typeof Math.PI").value, "number");
+		assert.equal(runtime.execute("JSON.stringify({a: 1})").value, '{"a":1}');
+		assert.equal(runtime.execute("Array.isArray([1, 2, 3])").value, true);
+		assert.equal(runtime.execute("[1, 2, 3].map(x => x * 2).join(',')").value, "2,4,6");
+		assert.equal(runtime.execute("new Map([[1, 'a']]).get(1)").value, "a");
+		assert.equal(runtime.execute("new Set([1, 2, 2, 3]).size").value, 3);
+	});
+
+	it("supports Promises and async execution", async () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		const result = await runtime.executeAsync("return await Promise.resolve(42);");
+		assert.equal(result.value, 42);
+	});
+});
+
+describe("host bindings", () => {
+	it("exposes top-level function bindings", () => {
+		const manifest = {
+			xript: "0.1",
+			name: "test",
+			bindings: {
+				add: { description: "Adds two numbers.", params: [{ name: "a", type: "number" }, { name: "b", type: "number" }], returns: "number" },
+			},
+		};
+		const runtime = createRuntime(manifest, {
+			hostBindings: { add: (a, b) => Number(a) + Number(b) },
+		});
+		assert.equal(runtime.execute("add(3, 4)").value, 7);
+	});
+
+	it("exposes namespace bindings", () => {
+		const manifest = {
+			xript: "0.1",
+			name: "test",
+			bindings: {
+				math: {
+					description: "Math operations.",
+					members: {
+						add: { description: "Adds.", params: [{ name: "a", type: "number" }, { name: "b", type: "number" }], returns: "number" },
+						multiply: { description: "Multiplies.", params: [{ name: "a", type: "number" }, { name: "b", type: "number" }], returns: "number" },
+					},
+				},
+			},
+		};
+		const runtime = createRuntime(manifest, {
+			hostBindings: {
+				math: {
+					add: (a, b) => Number(a) + Number(b),
+					multiply: (a, b) => Number(a) * Number(b),
+				},
+			},
+		});
+		assert.equal(runtime.execute("math.add(2, 3)").value, 5);
+		assert.equal(runtime.execute("math.multiply(4, 5)").value, 20);
+	});
+
+	it("wraps host errors in BindingError", () => {
+		const manifest = {
+			xript: "0.1",
+			name: "test",
+			bindings: { fail: { description: "Always fails." } },
+		};
+		const runtime = createRuntime(manifest, {
+			hostBindings: {
+				fail: () => {
+					throw new Error("host exploded");
+				},
+			},
+		});
+		const result = runtime.execute(`
+			let caught;
+			try { fail(); } catch (e) { caught = e; }
+			caught.name + ": " + caught.message;
+		`);
+		assert.ok(String(result.value).includes("BindingError"));
+		assert.ok(String(result.value).includes("host exploded"));
+	});
+
+	it("throws BindingError when host function is not provided", () => {
+		const manifest = {
+			xript: "0.1",
+			name: "test",
+			bindings: { missing: { description: "Missing binding." } },
+		};
+		const runtime = createRuntime(manifest, { hostBindings: {} });
+		const result = runtime.execute(`
+			let caught;
+			try { missing(); } catch (e) { caught = e; }
+			caught.name + ": " + caught.binding;
+		`);
+		assert.ok(String(result.value).includes("BindingError"));
+		assert.ok(String(result.value).includes("missing"));
+	});
+});
+
+describe("capability enforcement", () => {
+	const manifest = {
+		xript: "0.1",
+		name: "test",
+		bindings: {
+			readData: { description: "Reads data.", returns: "string" },
+			writeData: { description: "Writes data.", params: [{ name: "value", type: "string" }], capability: "storage" },
+			deleteData: { description: "Deletes data.", capability: "admin" },
+		},
+		capabilities: {
+			storage: { description: "Read/write storage.", risk: "low" },
+			admin: { description: "Admin operations.", risk: "high" },
+		},
+	};
+
+	it("allows ungated bindings without any capabilities", () => {
+		const runtime = createRuntime(manifest, {
+			hostBindings: { readData: () => "hello" },
+		});
+		assert.equal(runtime.execute("readData()").value, "hello");
+	});
+
+	it("throws CapabilityDeniedError for gated bindings without the capability", () => {
+		const runtime = createRuntime(manifest, {
+			hostBindings: { writeData: () => {} },
+		});
+		const result = runtime.execute(`
+			let caught;
+			try { writeData("test"); } catch (e) { caught = e; }
+			caught.name;
+		`);
+		assert.equal(result.value, "CapabilityDeniedError");
+	});
+
+	it("includes capability name in the error message", () => {
+		const runtime = createRuntime(manifest, {
+			hostBindings: { writeData: () => {} },
+		});
+		const result = runtime.execute(`
+			let msg;
+			try { writeData("test"); } catch (e) { msg = e.message; }
+			msg;
+		`);
+		assert.ok(String(result.value).includes("storage"));
+		assert.ok(String(result.value).includes("writeData"));
+	});
+
+	it("allows gated bindings when capability is granted", () => {
+		const runtime = createRuntime(manifest, {
+			hostBindings: {
+				readData: () => "hello",
+				writeData: (v) => `wrote: ${v}`,
+			},
+			capabilities: ["storage"],
+		});
+		assert.equal(runtime.execute("readData()").value, "hello");
+		assert.equal(runtime.execute("writeData('test')").value, "wrote: test");
+	});
+
+	it("denies capabilities not in the grant set", () => {
+		const runtime = createRuntime(manifest, {
+			hostBindings: {
+				readData: () => "hello",
+				writeData: () => {},
+				deleteData: () => {},
+			},
+			capabilities: ["storage"],
+		});
+		assert.equal(runtime.execute("readData()").value, "hello");
+		const result = runtime.execute(`
+			let caught;
+			try { deleteData(); } catch (e) { caught = e.name; }
+			caught;
+		`);
+		assert.equal(result.value, "CapabilityDeniedError");
+	});
+
+	it("does not execute the function when capability is denied", () => {
+		let called = false;
+		const runtime = createRuntime(manifest, {
+			hostBindings: {
+				writeData: () => { called = true; },
+			},
+		});
+		runtime.execute(`
+			try { writeData("test"); } catch (e) {}
+		`);
+		assert.equal(called, false);
+	});
+});
+
+describe("sandbox isolation", () => {
+	it("blocks eval()", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		const result = runtime.execute(`
+			let caught;
+			try { eval("1 + 1"); } catch (e) { caught = e; }
+			caught.name + ": " + caught.message;
+		`);
+		assert.ok(String(result.value).includes("TypeError"));
+		assert.ok(String(result.value).includes("not permitted"));
+	});
+
+	it("blocks new Function()", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		const result = runtime.execute(`
+			let caught;
+			try { new Function("return 1"); } catch (e) { caught = e; }
+			caught.message;
+		`);
+		assert.ok(String(result.value).includes("not permitted"));
+	});
+
+	it("blocks code generation via vm codeGeneration option", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		const result = runtime.execute(`
+			let blocked = false;
+			try {
+				(0, eval)("1");
+			} catch (e) {
+				blocked = true;
+			}
+			blocked;
+		`);
+		assert.equal(result.value, true);
+	});
+
+	it("does not expose process, require, or import", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		assert.equal(runtime.execute("typeof process").value, "undefined");
+		assert.equal(runtime.execute("typeof require").value, "undefined");
+		assert.equal(runtime.execute("typeof module").value, "undefined");
+	});
+
+	it("does not expose fetch, setTimeout, or setInterval", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		assert.equal(runtime.execute("typeof fetch").value, "undefined");
+		assert.equal(runtime.execute("typeof setTimeout").value, "undefined");
+		assert.equal(runtime.execute("typeof setInterval").value, "undefined");
+	});
+
+	it("does not expose Node.js specific globals", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		assert.equal(runtime.execute("typeof Buffer").value, "undefined");
+		assert.equal(runtime.execute("typeof __dirname").value, "undefined");
+		assert.equal(runtime.execute("typeof __filename").value, "undefined");
+	});
+
+	it("namespace objects are frozen", () => {
+		const manifest = {
+			xript: "0.1",
+			name: "test",
+			bindings: {
+				ns: {
+					description: "A namespace.",
+					members: { fn: { description: "A function.", returns: "string" } },
+				},
+			},
+		};
+		const runtime = createRuntime(manifest, {
+			hostBindings: { ns: { fn: () => "original" } },
+		});
+		const result = runtime.execute(`
+			"use strict";
+			let tampered = false;
+			try {
+				ns.fn = () => "hacked";
+			} catch (e) {
+				tampered = true;
+			}
+			tampered;
+		`);
+		assert.equal(result.value, true);
+	});
+});
+
+describe("execution limits", () => {
+	it("terminates scripts that exceed timeout", () => {
+		const manifest = {
+			xript: "0.1",
+			name: "test",
+			limits: { timeout_ms: 50 },
+		};
+		const runtime = createRuntime(manifest, { hostBindings: {} });
+		assert.throws(
+			() => runtime.execute("while (true) {}"),
+			(err) => err.code === "ERR_SCRIPT_EXECUTION_TIMEOUT" || err.message.includes("timed out"),
+		);
+	});
+
+	it("uses default 5000ms timeout when limits are not specified", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		const result = runtime.execute("1 + 1");
+		assert.equal(result.value, 2);
+	});
+
+	it("short timeout still allows quick scripts", () => {
+		const manifest = {
+			xript: "0.1",
+			name: "test",
+			limits: { timeout_ms: 100 },
+		};
+		const runtime = createRuntime(manifest, { hostBindings: {} });
+		const result = runtime.execute("42");
+		assert.equal(result.value, 42);
+	});
+});
+
+describe("console", () => {
+	it("routes console.log to host console", () => {
+		const logs = [];
+		const runtime = createRuntime(minimalManifest, {
+			hostBindings: {},
+			console: {
+				log: (...args) => logs.push(args),
+				warn: () => {},
+				error: () => {},
+			},
+		});
+		runtime.execute('console.log("hello", 42)');
+		assert.equal(logs.length, 1);
+		assert.deepEqual(logs[0], ["hello", 42]);
+	});
+
+	it("routes console.warn and console.error to host console", () => {
+		const warns = [];
+		const errors = [];
+		const runtime = createRuntime(minimalManifest, {
+			hostBindings: {},
+			console: {
+				log: () => {},
+				warn: (...args) => warns.push(args),
+				error: (...args) => errors.push(args),
+			},
+		});
+		runtime.execute('console.warn("warning"); console.error("error")');
+		assert.equal(warns.length, 1);
+		assert.equal(errors.length, 1);
+	});
+});
+
+describe("state isolation between executions", () => {
+	it("persists state within the same runtime", () => {
+		const runtime = createRuntime(minimalManifest, { hostBindings: {} });
+		runtime.execute("var counter = 0;");
+		runtime.execute("counter++;");
+		const result = runtime.execute("counter");
+		assert.equal(result.value, 1);
+	});
+});
+
+describe("createRuntimeFromFile", () => {
+	it("loads a manifest from a file", async () => {
+		const runtime = await createRuntimeFromFile("../../examples/game-mod-system.json", {
+			hostBindings: {
+				log: (msg) => msg,
+				player: {
+					getName: () => "Hero",
+					getHealth: () => 100,
+					getMaxHealth: () => 100,
+					getPosition: () => ({ x: 5, y: 10 }),
+					setHealth: () => {},
+					getInventory: () => [],
+					addItem: () => {},
+				},
+				world: {
+					getCurrentLevel: () => 3,
+					getEnemies: async () => [],
+					spawnEnemy: () => {},
+				},
+				data: {
+					get: async () => undefined,
+					set: async () => {},
+				},
+			},
+			capabilities: ["modify-player", "modify-world", "storage"],
+		});
+		assert.equal(runtime.manifest.name, "dungeon-crawler");
+		assert.equal(runtime.execute("player.getName()").value, "Hero");
+		assert.equal(runtime.execute("player.getHealth()").value, 100);
+		assert.equal(runtime.execute("world.getCurrentLevel()").value, 3);
+	});
+});

--- a/runtimes/js/tsconfig.json
+++ b/runtimes/js/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"declaration": true,
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true
+	},
+	"include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

- Built `@xript/runtime-js`, the reference JavaScript runtime for xript, in `runtimes/js/`
- Uses Node.js `vm` module for sandboxed execution with `codeGeneration: { strings: false, wasm: false }`
- Implements the full xript security model:
  - **Sandbox isolation**: restricted global environment, no access to `process`/`require`/`fetch`/`setTimeout`/`Buffer` etc.
  - **Capability enforcement**: default-deny, `CapabilityDeniedError` on gated calls, function never executes on denial
  - **No eval**: `eval()` and `new Function()` blocked at both custom and vm engine level
  - **Execution limits**: configurable timeout via manifest `limits.timeout_ms`
- Host bindings wired from manifest: top-level functions, frozen namespace objects, error wrapping via `BindingError`
- Clean API: `createRuntime(manifest, options)` and `createRuntimeFromFile(path, options)` with `execute()` / `executeAsync()`
- 30 tests across 9 suites covering all spec guarantees
- Also updates `CLAUDE.md` to reflect current project state (#19)

## Test plan

- [x] All 30 tests pass (`npm test` in `runtimes/js/`)
- [x] TypeScript builds cleanly (`tsc`)
- [x] Runtime works with the full `game-mod-system.json` example manifest
- [x] Sandbox blocks eval, Function constructor, and code generation
- [x] Capability denial prevents function execution (verified with side-effect check)
- [x] Timeout terminates infinite loops
- [x] Platform globals (process, require, fetch, setTimeout, Buffer) are inaccessible

Closes #6, closes #19