### PR TITLE
runtime API docs and example walkthroughs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -34,9 +34,17 @@ export default defineConfig({
 				{
 					label: "Tools",
 					items: [
+						{ label: "Runtime", slug: "tools/runtime" },
 						{ label: "Manifest Validator", slug: "tools/validator" },
 						{ label: "Type Generator", slug: "tools/typegen" },
 						{ label: "Doc Generator", slug: "tools/docgen" },
+					],
+				},
+				{
+					label: "Examples",
+					items: [
+						{ label: "Expression Evaluator", slug: "examples/expression-evaluator" },
+						{ label: "Plugin System", slug: "examples/plugin-system" },
 					],
 				},
 			],

--- a/docs/src/content/docs/examples/expression-evaluator.md
+++ b/docs/src/content/docs/examples/expression-evaluator.md
@@ -1,0 +1,102 @@
+---
+title: "Example: Expression Evaluator"
+description: A tier 1 integration walkthrough — safe expression evaluation with flat bindings.
+---
+
+This example demonstrates the simplest way to use xript: exposing a set of flat functions to user scripts with no capabilities, no namespaces, and no custom types. This is **tier 1** adoption.
+
+The full source is in [`examples/expression-evaluator/`](https://github.com/nekoyoubi/xript/tree/main/examples/expression-evaluator).
+
+## The Manifest
+
+The manifest declares 11 bindings across two categories: math operations and string operations.
+
+```json
+{
+  "xript": "0.1",
+  "name": "expression-evaluator",
+  "version": "1.0.0",
+  "title": "Expression Evaluator",
+  "bindings": {
+    "abs":   { "description": "Returns the absolute value.", "params": [{ "name": "x", "type": "number" }], "returns": "number" },
+    "round": { "description": "Rounds to the nearest integer.", "params": [{ "name": "x", "type": "number" }], "returns": "number" },
+    "clamp": { "description": "Clamps a value between lo and hi.", "params": [{ "name": "value", "type": "number" }, { "name": "lo", "type": "number" }, { "name": "hi", "type": "number" }], "returns": "number" },
+    "upper": { "description": "Converts to uppercase.", "params": [{ "name": "s", "type": "string" }], "returns": "string" },
+    "concat": { "description": "Concatenates two strings.", "params": [{ "name": "a", "type": "string" }, { "name": "b", "type": "string" }], "returns": "string" }
+  }
+}
+```
+
+*(Truncated for readability -- the full manifest includes `floor`, `ceil`, `min`, `max`, `lower`, and `len`.)*
+
+There are no `capabilities`, no `types`, and no `limits` sections. This is as minimal as it gets while still being useful.
+
+## The Host
+
+The host provides one JavaScript function for each binding:
+
+```javascript
+import { createRuntime } from "@xript/runtime-js";
+
+const hostBindings = {
+  abs: (x) => Math.abs(x),
+  round: (x) => Math.round(x),
+  floor: (x) => Math.floor(x),
+  ceil: (x) => Math.ceil(x),
+  min: (a, b) => Math.min(a, b),
+  max: (a, b) => Math.max(a, b),
+  clamp: (value, lo, hi) => Math.min(Math.max(value, lo), hi),
+  upper: (s) => String(s).toUpperCase(),
+  lower: (s) => String(s).toLowerCase(),
+  len: (s) => String(s).length,
+  concat: (a, b) => String(a) + String(b),
+};
+
+const runtime = createRuntime(manifest, { hostBindings });
+```
+
+Each binding is a pure function with no side effects. This is the safest kind of integration -- users can compose expressions but cannot modify any application state.
+
+## What Users Can Do
+
+Users write expressions that combine your bindings with standard JavaScript:
+
+```javascript
+runtime.execute("abs(-42)");                    // 42
+runtime.execute("clamp(round(3.7), 0, 3)");     // 3
+runtime.execute('upper(concat("hello", " xript"))'); // "HELLO XRIPT"
+runtime.execute("[1, 2, 3].map(x => abs(x - 5))");  // [4, 3, 2]
+```
+
+Standard JavaScript features like array methods, template literals, and arrow functions all work inside the sandbox.
+
+## What Users Cannot Do
+
+The sandbox blocks everything not declared in the manifest:
+
+```javascript
+runtime.execute('eval("1 + 1")');       // TypeError: eval() is not permitted
+runtime.execute("process.exit(1)");      // ReferenceError: process is not defined
+runtime.execute('require("fs")');        // ReferenceError: require is not defined
+runtime.execute("fetch('https://...')"); // ReferenceError: fetch is not defined
+```
+
+## Running the Demo
+
+```sh
+cd examples/expression-evaluator
+node src/demo.js
+```
+
+The demo runs all the expressions above and prints their results, including the sandbox enforcement tests.
+
+## When to Use This Pattern
+
+Tier 1 is the right choice when:
+
+- You want users to write **formulas or expressions**, not full scripts
+- All operations are **read-only** with no side effects
+- You do not need to gate any functionality behind permissions
+- You want the **smallest possible manifest** and integration surface
+
+To move beyond tier 1, add [namespaces](/spec/manifest#namespaces), [capabilities](/spec/capabilities), and [custom types](/spec/manifest#types). See the [Plugin System](/examples/plugin-system) example for a tier 2 walkthrough.

--- a/docs/src/content/docs/examples/plugin-system.md
+++ b/docs/src/content/docs/examples/plugin-system.md
@@ -1,0 +1,180 @@
+---
+title: "Example: Plugin System"
+description: A tier 2 integration walkthrough — namespaces, capabilities, and custom types.
+---
+
+This example demonstrates a full-featured plugin system using xript's tier 2 features: namespaces to organize bindings, capabilities to gate destructive operations, and custom types to describe data structures. Five plugins run against the same host, each with a different permission profile.
+
+The full source is in [`examples/plugin-system/`](https://github.com/nekoyoubi/xript/tree/main/examples/plugin-system).
+
+## The Manifest
+
+The manifest declares a `tasks` namespace with five methods and a top-level `log` function:
+
+```json
+{
+  "xript": "0.1",
+  "name": "task-manager",
+  "version": "1.0.0",
+  "bindings": {
+    "tasks": {
+      "description": "Read and manage tasks.",
+      "members": {
+        "list":     { "description": "Returns all tasks.", "returns": { "array": "Task" } },
+        "get":      { "description": "Returns a task by ID.", "params": [{ "name": "id", "type": "string" }] },
+        "add":      { "description": "Creates a new task.", "params": [...], "capability": "manage-tasks" },
+        "complete": { "description": "Marks a task as done.", "params": [...], "capability": "manage-tasks" },
+        "remove":   { "description": "Permanently removes a task.", "params": [...], "capability": "admin" }
+      }
+    },
+    "log": { "description": "Writes a message to the plugin console.", "params": [...] }
+  }
+}
+```
+
+Key observations:
+
+- `tasks.list` and `tasks.get` have **no capability gate** -- any plugin can read tasks
+- `tasks.add` and `tasks.complete` require the **`manage-tasks`** capability
+- `tasks.remove` requires the **`admin`** capability -- a higher privilege tier
+- `log` is a top-level function with no gate
+
+### Capabilities
+
+```json
+{
+  "capabilities": {
+    "manage-tasks": { "description": "Create and complete tasks.", "risk": "medium" },
+    "admin": { "description": "Delete tasks and admin operations.", "risk": "high" }
+  }
+}
+```
+
+### Custom Types
+
+```json
+{
+  "types": {
+    "Task": {
+      "description": "A task in the task manager.",
+      "fields": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "done": { "type": "boolean" },
+        "priority": { "type": "Priority" },
+        "createdAt": { "type": "string" }
+      }
+    },
+    "Priority": {
+      "description": "Task priority levels.",
+      "values": ["low", "medium", "high", "urgent"]
+    }
+  }
+}
+```
+
+Types do not enforce runtime validation -- they serve as documentation for plugin authors and feed into tools like `xript-typegen` and `xript-docgen`.
+
+## The Host
+
+The host creates a shared task store and wires up the namespace methods:
+
+```javascript
+const taskStore = [];
+
+const hostBindings = {
+  tasks: {
+    list: () => [...taskStore],
+    get: (id) => taskStore.find((t) => t.id === id),
+    add: (title, priority) => {
+      const task = { id: String(nextId++), title, done: false, priority, createdAt: new Date().toISOString() };
+      taskStore.push(task);
+      return task;
+    },
+    complete: (id) => { /* mark done */ },
+    remove: (id) => { /* splice from array */ },
+  },
+  log: (msg) => console.log(`[plugin] ${msg}`),
+};
+```
+
+Each plugin gets its own runtime instance but shares the same underlying `taskStore`. This means plugins can see each other's changes -- a deliberate design choice for this example.
+
+## The Five Plugins
+
+### 1. Task Reporter (no capabilities)
+
+```javascript
+const runtime = createRuntime(manifest, { hostBindings, capabilities: [] });
+runtime.execute("tasks.list()");
+runtime.execute('log("Found " + tasks.list().length + " tasks")');
+```
+
+Can read tasks and call `log`, but cannot create, complete, or remove tasks.
+
+### 2. Task Creator (manage-tasks)
+
+```javascript
+const runtime = createRuntime(manifest, { hostBindings, capabilities: ["manage-tasks"] });
+runtime.execute('tasks.add("Write documentation", "high")');
+runtime.execute('tasks.complete("1")');
+```
+
+Can create and complete tasks, but cannot remove them (no `admin` capability).
+
+### 3. Read-Only Dashboard (no capabilities)
+
+```javascript
+const runtime = createRuntime(manifest, { hostBindings, capabilities: [] });
+runtime.execute('tasks.list().filter(t => !t.done).length'); // works
+runtime.execute('tasks.add("Sneaky task", "low")');          // CapabilityDeniedError
+```
+
+Demonstrates that even after other plugins have created tasks, a plugin without capabilities still cannot modify them.
+
+### 4. Admin Cleanup (manage-tasks + admin)
+
+```javascript
+const runtime = createRuntime(manifest, { hostBindings, capabilities: ["manage-tasks", "admin"] });
+runtime.execute('tasks.remove("1")');
+```
+
+Full access. Can read, create, complete, and remove tasks.
+
+### 5. Privilege Escalation Attempt (manage-tasks only)
+
+```javascript
+const runtime = createRuntime(manifest, { hostBindings, capabilities: ["manage-tasks"] });
+runtime.execute('tasks.remove("2")'); // CapabilityDeniedError: requires "admin"
+```
+
+Having `manage-tasks` does not grant `admin`. Each capability must be explicitly granted.
+
+## Running the Demo
+
+```sh
+cd examples/plugin-system
+node src/demo.js
+```
+
+The demo runs all five plugins sequentially, showing which operations succeed and which are denied.
+
+## Concepts Demonstrated
+
+| Concept | Where |
+|---------|-------|
+| Namespaces | `tasks.list()`, `tasks.add()` |
+| Capability gating | `manage-tasks` on add/complete, `admin` on remove |
+| Tiered permissions | Plugin 5 has `manage-tasks` but not `admin` |
+| Custom types | `Task` and `Priority` in the manifest |
+| Default-deny | Plugins 1 and 3 get read-only access |
+| Shared state | All plugins see the same task store |
+
+## When to Use This Pattern
+
+Tier 2 is the right choice when:
+
+- You need to **organize bindings into logical groups** (namespaces)
+- Some operations are **destructive or sensitive** and need permission gating
+- You want to **document data structures** for plugin authors
+- Different plugins need **different permission levels**

--- a/docs/src/content/docs/tools/runtime.md
+++ b/docs/src/content/docs/tools/runtime.md
@@ -1,0 +1,171 @@
+---
+title: Runtime
+description: Reference JavaScript runtime for sandboxed script execution with manifest-driven bindings.
+---
+
+The reference runtime (`@xript/runtime-js`) executes user scripts inside a secure sandbox. It reads a manifest to determine which bindings to expose, enforces capability gates, and prevents access to anything outside the declared surface.
+
+## Installation
+
+```sh
+npm install @xript/runtime-js
+```
+
+The runtime uses Node.js's built-in `vm` module for sandboxing. No native dependencies.
+
+## Creating a Runtime
+
+### From an inline manifest
+
+```javascript
+import { createRuntime } from "@xript/runtime-js";
+
+const runtime = createRuntime(manifest, {
+  hostBindings: { greet: (name) => `Hello, ${name}!` },
+});
+```
+
+`createRuntime(manifest, options)` is synchronous. It performs structural validation on the manifest (checks required fields, correct types, valid limits) and throws `ManifestValidationError` if anything is wrong.
+
+### From a file
+
+```javascript
+import { createRuntimeFromFile } from "@xript/runtime-js";
+
+const runtime = await createRuntimeFromFile("./manifest.json", {
+  hostBindings: { greet: (name) => `Hello, ${name}!` },
+});
+```
+
+`createRuntimeFromFile(path, options)` is asynchronous. It validates the manifest against the full JSON Schema (via `@xript/manifest-validator`) by default, then creates the runtime.
+
+## Options
+
+Both functions accept the same `RuntimeOptions` object:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `hostBindings` | `HostBindings` | (required) | Map of binding names to host functions |
+| `capabilities` | `string[]` | `[]` | List of capabilities granted to this script |
+| `validate` | `boolean` | `true` for file, N/A for inline | Whether to run full JSON Schema validation |
+| `console` | `{ log, warn, error }` | no-op functions | Console output routing |
+
+### Host Bindings
+
+Host bindings are a flat object mapping binding names to functions, or namespace names to objects of functions:
+
+```javascript
+const hostBindings = {
+  log: (msg) => console.log(msg),
+  player: {
+    getName: () => "Hero",
+    getHealth: () => 80,
+    setHealth: (value) => { health = value; },
+  },
+};
+```
+
+Every binding declared in the manifest should have a corresponding host function. If a manifest binding has no host function, calling it throws a `BindingError`.
+
+### Capabilities
+
+Capabilities are an opt-in security layer. By default, no capabilities are granted. Pass the capability names the script should have access to:
+
+```javascript
+const runtime = createRuntime(manifest, {
+  hostBindings,
+  capabilities: ["modify-player", "storage"],
+});
+```
+
+Any call to a binding gated by a capability not in this list throws a `CapabilityDeniedError`.
+
+## Executing Scripts
+
+### Synchronous
+
+```javascript
+const result = runtime.execute("2 + 2");
+// { value: 4, duration_ms: 0.5 }
+```
+
+`execute(code)` runs the code synchronously and returns an `ExecutionResult`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `value` | `unknown` | The result of the last expression |
+| `duration_ms` | `number` | Wall-clock execution time in milliseconds |
+
+### Asynchronous
+
+```javascript
+const result = await runtime.executeAsync("return await data.get('score');");
+// { value: "42", duration_ms: 1.2 }
+```
+
+`executeAsync(code)` wraps the code in an async function. Use `return` and `await` as needed. Returns a Promise resolving to an `ExecutionResult`.
+
+## Error Types
+
+The runtime exports four error classes, all available as named imports:
+
+### ManifestValidationError
+
+Thrown when the manifest fails structural or schema validation.
+
+```javascript
+import { ManifestValidationError } from "@xript/runtime-js";
+
+try {
+  createRuntime({}, { hostBindings: {} });
+} catch (e) {
+  // e.name === "ManifestValidationError"
+  // e.issues === [{ path: "/xript", message: "required field..." }, ...]
+}
+```
+
+The `issues` array contains every problem found, with a `path` and `message` for each.
+
+### BindingError
+
+Thrown when a host function throws or is not provided.
+
+```javascript
+import { BindingError } from "@xript/runtime-js";
+// e.name === "BindingError"
+// e.binding === "player.getHealth"
+// e.message includes the original error message
+```
+
+### CapabilityDeniedError
+
+Thrown when calling a capability-gated binding without the required capability.
+
+```javascript
+import { CapabilityDeniedError } from "@xript/runtime-js";
+// e.name === "CapabilityDeniedError"
+// e.capability === "modify-player"
+// e.binding === "player.setHealth"
+```
+
+### ExecutionLimitError
+
+Thrown when the script exceeds configured execution limits (timeout, memory).
+
+```javascript
+import { ExecutionLimitError } from "@xript/runtime-js";
+// e.name === "ExecutionLimitError"
+// e.limit === "timeout_ms"
+```
+
+## Sandbox Details
+
+The sandbox provides a restricted JavaScript environment:
+
+**Available:** `Math`, `JSON`, `Date`, `Number`, `String`, `Boolean`, `Array`, `Object`, `Map`, `Set`, `WeakMap`, `WeakSet`, `Promise`, `RegExp`, `Symbol`, `Proxy`, `Reflect`, typed arrays, `parseInt`, `parseFloat`, `isNaN`, `isFinite`, and all standard error constructors.
+
+**Blocked:** `eval`, `new Function`, `process`, `require`, `import`, `fetch`, `setTimeout`, `setInterval`, `Buffer`, `__dirname`, `__filename`, and all Node.js-specific globals.
+
+**Frozen namespaces:** Namespace objects are frozen with `Object.freeze`. Scripts cannot add, remove, or reassign namespace members.
+
+**Execution limits:** The `timeout_ms` field in the manifest's `limits` section controls how long a script can run. Default is 5000ms.


### PR DESCRIPTION
## Summary
- Added runtime API reference page documenting all public exports, options, and error types (#33)
- Added tier 1 (expression evaluator) and tier 2 (plugin system) example walkthrough pages (#34)
- Updated sidebar with Runtime entry under Tools and new Examples section
- Docs site builds 14 pages (up from 11)

## Test plan
- [x] Docs build succeeds with all 14 pages
- [x] Sidebar renders correctly with new sections

Closes #33, closes #34