### PR TITLE
renamed runtime package, fixed stale docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
       - name: test docgen
         run: npm test --workspace=tools/docgen
 
-      - name: build runtime-js
+      - name: build runtime
         run: npm run build --workspace=runtimes/js
-      - name: test runtime-js
+      - name: test runtime
         run: npm test --workspace=runtimes/js
 
       - name: build runtime-node
@@ -61,7 +61,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - name: build runtime-js
+      - name: build runtime
         run: npm run build --workspace=runtimes/js
       - name: build docs
         run: npm run docs:build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build runtime-js
+      - name: Build runtime
         run: npm run build --workspace=runtimes/js
 
       - name: Build docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This is a monorepo managed via npm workspaces.
 xript/
 ├── spec/           # the specification (manifest schema, capability model, etc.)
 ├── runtimes/       # language-specific runtime implementations
-│   ├── js/         # universal runtime (@xript/runtime-js, QuickJS WASM sandbox)
+│   ├── js/         # universal runtime (@xript/runtime, QuickJS WASM sandbox)
 │   └── node/       # Node.js-optimized runtime (@xript/runtime-node, vm-based)
 ├── tools/          # ecosystem tooling (validator, typegen, docgen)
 ├── docs/           # documentation site (Astro + Starlight), deployed to xript.dev
@@ -21,7 +21,7 @@ xript/
 
 ## Tech Stack
 
-- **Docs site**: Astro with Starlight, deployed to GitHub Pages via GitHub Actions (live demos depend on `@xript/runtime-js` -- CI builds the runtime before docs)
+- **Docs site**: Astro with Starlight, deployed to GitHub Pages via GitHub Actions (live demos depend on `@xript/runtime` -- CI builds the runtime before docs)
 - **Package management**: npm workspaces
 - **Language**: TypeScript throughout
 - **Runtime sandbox (js)**: QuickJS compiled to WASM via `quickjs-emscripten` — runs in browser, Node, Deno, and more
@@ -72,10 +72,10 @@ node examples/game-mod-system/src/demo.js        # tier 3 demo
 All v0.1 milestones are complete:
 
 - **Spec v0.1**: manifest schema (JSON Schema draft 2020-12), capability model, binding conventions, and security guarantees documented in `spec/`
-- **Universal Runtime**: `@xript/runtime-js` in `runtimes/js/` -- QuickJS WASM sandbox with capability enforcement, 58 tests (36 unit + 22 integration)
+- **Universal Runtime**: `@xript/runtime` in `runtimes/js/` -- QuickJS WASM sandbox with capability enforcement, 58 tests (36 unit + 22 integration)
 - **Node.js Runtime**: `@xript/runtime-node` in `runtimes/node/` -- Node.js vm-based sandbox with `createRuntimeFromFile` and full schema validation, 60 tests
 - **Toolchain**: manifest validator, type generator, and doc generator all built and tested in `tools/` (45 tests across 3 packages)
-- **Developer Experience**: docs site at xript.dev (20 pages), getting started guide, runtime API reference, three example walkthroughs, three interactive live demos (browser-only QuickJS WASM), CI with smoke tests
+- **Developer Experience**: docs site at xript.dev (19 pages), getting started guide, runtime API reference, three example walkthroughs, three interactive live demos (browser-only QuickJS WASM), CI with smoke tests
 - **Hardening**: integration tests, manifest validation in runtime, example smoke tests in CI
 
 Total test count: 163 across 6 packages. All green.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ This installs dependencies for all workspace packages. The repo is a monorepo ma
 xript/
 ├── spec/           # the specification (manifest schema, capability model, etc.)
 ├── runtimes/
-│   ├── js/         # universal runtime (@xript/runtime-js, QuickJS WASM sandbox)
+│   ├── js/         # universal runtime (@xript/runtime, QuickJS WASM sandbox)
 │   └── node/       # Node.js-optimized runtime (@xript/runtime-node, vm-based)
 ├── tools/          # ecosystem tooling (validator, typegen, docgen)
 ├── docs/           # documentation site (Astro + Starlight) → xript.dev

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ One JSON manifest. Everything else is derived.
 ## Quick Start
 
 ```sh
-npm install @xript/runtime-js
+npm install @xript/runtime
 ```
 
 ```javascript
-import { initXript } from "@xript/runtime-js";
+import { initXript } from "@xript/runtime";
 
 const xript = await initXript();
 const runtime = xript.createRuntime(
@@ -70,7 +70,7 @@ runtime.dispose();
 xript/
 ├── spec/           # the specification (manifest schema, capabilities, bindings, security)
 ├── runtimes/
-│   ├── js/         # universal runtime (@xript/runtime-js, QuickJS WASM sandbox)
+│   ├── js/         # universal runtime (@xript/runtime, QuickJS WASM sandbox)
 │   └── node/       # Node.js-optimized runtime (@xript/runtime-node, vm-based)
 ├── tools/
 │   ├── manifest-validator/  # @xript/manifest-validator
@@ -105,7 +105,7 @@ npx xript-docgen manifest.json -o docs/  # generate documentation
 | Universal Runtime | Complete -- QuickJS WASM sandbox, runs in browser/Node/Deno/Bun |
 | Node.js Runtime | Complete -- Node.js vm-based sandbox with `createRuntimeFromFile` and JSON Schema validation |
 | Toolchain | Complete -- validator, typegen, docgen |
-| Developer Experience | Complete -- 17-page docs site, getting started guide, runtime API reference, example walkthroughs |
+| Developer Experience | Complete -- 19-page docs site, getting started guide, runtime API reference, example walkthroughs, live demos |
 | Hardening | Complete -- 163 tests across 6 packages, manifest validation, CI smoke tests |
 
 ## License

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -4,6 +4,7 @@ import starlight from "@astrojs/starlight";
 
 export default defineConfig({
 	site: "https://xript.dev",
+	prefetch: false,
 	integrations: [
 		starlight({
 			title: "xript",
@@ -98,7 +99,7 @@ export default defineConfig({
 	],
 	vite: {
 		optimizeDeps: {
-			exclude: ["@xript/runtime-js", "quickjs-emscripten"],
+			exclude: ["@xript/runtime", "quickjs-emscripten"],
 		},
 	},
 	server: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
 		"@astrojs/starlight": "^0.37.6",
 		"@fontsource-variable/inter": "^5.2.8",
 		"@fontsource/jetbrains-mono": "^5.2.8",
-		"@xript/runtime-js": "^0.2.0",
+		"@xript/runtime": "^0.2.0",
 		"astro": "^5.17.1"
 	}
 }

--- a/docs/src/components/DungeonModding.astro
+++ b/docs/src/components/DungeonModding.astro
@@ -58,7 +58,7 @@
 </div>
 
 <script>
-	import { initXriptAsync } from "@xript/runtime-js";
+	import { initXriptAsync } from "@xript/runtime";
 
 	const GRID_W = 16;
 	const GRID_H = 10;

--- a/docs/src/components/ExpressionPlayground.astro
+++ b/docs/src/components/ExpressionPlayground.astro
@@ -48,7 +48,7 @@
 </div>
 
 <script>
-	import { initXript } from "@xript/runtime-js";
+	import { initXript } from "@xript/runtime";
 
 	const manifest = {
 		xript: "0.1",

--- a/docs/src/components/PluginWorkshop.astro
+++ b/docs/src/components/PluginWorkshop.astro
@@ -72,7 +72,7 @@
 </div>
 
 <script>
-	import { initXript } from "@xript/runtime-js";
+	import { initXript } from "@xript/runtime";
 
 	const manifest = {
 		xript: "0.1",

--- a/docs/src/content/docs/examples/expression-evaluator.md
+++ b/docs/src/content/docs/examples/expression-evaluator.md
@@ -36,7 +36,7 @@ There are no `capabilities`, no `types`, and no `limits` sections. This is as mi
 The host provides one JavaScript function for each binding:
 
 ```javascript
-import { initXript } from "@xript/runtime-js";
+import { initXript } from "@xript/runtime";
 
 const hostBindings = {
   abs: (x) => Math.abs(x),

--- a/docs/src/content/docs/examples/game-mod-system.md
+++ b/docs/src/content/docs/examples/game-mod-system.md
@@ -107,7 +107,7 @@ A 1-second timeout is appropriate for game mods that run per-frame or per-event.
 The host simulates a dungeon crawler with in-memory game state:
 
 ```javascript
-import { initXriptAsync } from "@xript/runtime-js";
+import { initXriptAsync } from "@xript/runtime";
 
 const xript = await initXriptAsync();
 const runtime = await xript.createRuntime(manifest, {

--- a/docs/src/content/docs/examples/plugin-system.md
+++ b/docs/src/content/docs/examples/plugin-system.md
@@ -103,7 +103,7 @@ Each plugin gets its own runtime instance but shares the same underlying `taskSt
 The factory is initialized once, then each plugin creates a runtime from it:
 
 ```javascript
-import { initXript } from "@xript/runtime-js";
+import { initXript } from "@xript/runtime";
 const xript = await initXript();
 ```
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -10,7 +10,7 @@ This guide walks through adding xript to an application from scratch. By the end
 The universal runtime uses QuickJS compiled to WebAssembly — it works in browsers, Node.js, Deno, and more.
 
 ```sh
-npm install @xript/runtime-js
+npm install @xript/runtime
 ```
 
 ## Write a Manifest
@@ -58,7 +58,7 @@ const hostBindings = {
 Initialize the WASM sandbox, then wire the manifest and bindings together:
 
 ```javascript
-import { initXript } from "@xript/runtime-js";
+import { initXript } from "@xript/runtime";
 
 const xript = await initXript();
 const runtime = xript.createRuntime(manifest, {

--- a/docs/src/content/docs/spec/manifest.md
+++ b/docs/src/content/docs/spec/manifest.md
@@ -3,7 +3,7 @@ title: Manifest Specification
 description: The xript manifest format — how applications declare their scripting API.
 ---
 
-The xript manifest is the single source of truth for an application's scripting API. It declares what functionality is exposed to scripts, how it is organized, what capabilities gate access, and what types are involved. From the manifest, everything else is derived: documentation, TypeScript definitions, and validation. Interactive playgrounds are planned as a future toolchain output.
+The xript manifest is the single source of truth for an application's scripting API. It declares what functionality is exposed to scripts, how it is organized, what capabilities gate access, and what types are involved. From the manifest, everything else is derived: documentation, TypeScript definitions, and validation. Interactive playgrounds are also supported as a toolchain output.
 
 ## Overview
 

--- a/docs/src/content/docs/tools/runtime-node.md
+++ b/docs/src/content/docs/tools/runtime-node.md
@@ -5,11 +5,11 @@ description: Node.js-optimized xript runtime with file-based manifest loading an
 
 The Node.js runtime (`@xript/runtime-node`) executes user scripts inside a sandboxed Node.js `vm` context. It provides `createRuntimeFromFile` for loading manifests directly from disk and full JSON Schema validation via `@xript/manifest-validator`. Use this runtime when your application runs exclusively on Node.js and you want file-based workflows or stricter manifest validation.
 
-For applications that need to run in browsers, Deno, Bun, or other environments, use the [universal runtime](/tools/runtime) (`@xript/runtime-js`) instead.
+For applications that need to run in browsers, Deno, Bun, or other environments, use the [universal runtime](/tools/runtime) (`@xript/runtime`) instead.
 
 ## When to Use Which Runtime
 
-| | Universal (`@xript/runtime-js`) | Node.js (`@xript/runtime-node`) |
+| | Universal (`@xript/runtime`) | Node.js (`@xript/runtime-node`) |
 |---|---|---|
 | **Sandbox** | QuickJS WASM | Node.js `vm` module |
 | **Environments** | Browser, Node, Deno, Bun, Workers | Node.js only |

--- a/docs/src/content/docs/tools/runtime.md
+++ b/docs/src/content/docs/tools/runtime.md
@@ -3,14 +3,14 @@ title: Runtime
 description: Universal JavaScript runtime for sandboxed script execution with manifest-driven bindings.
 ---
 
-The universal runtime (`@xript/runtime-js`) executes user scripts inside a secure QuickJS WASM sandbox. It reads a manifest to determine which bindings to expose, enforces capability gates, and prevents access to anything outside the declared surface. It runs in any JavaScript environment: browser, Node.js, Deno, Bun, and Cloudflare Workers.
+The universal runtime (`@xript/runtime`) executes user scripts inside a secure QuickJS WASM sandbox. It reads a manifest to determine which bindings to expose, enforces capability gates, and prevents access to anything outside the declared surface. It runs in any JavaScript environment: browser, Node.js, Deno, Bun, and Cloudflare Workers.
 
 For Node.js-only applications that need `createRuntimeFromFile` or full JSON Schema validation, see `@xript/runtime-node`.
 
 ## Installation
 
 ```sh
-npm install @xript/runtime-js
+npm install @xript/runtime
 ```
 
 The runtime uses QuickJS compiled to WebAssembly for sandboxing. No native dependencies.
@@ -20,7 +20,7 @@ The runtime uses QuickJS compiled to WebAssembly for sandboxing. No native depen
 The runtime uses a factory pattern. First, initialize the WASM module (done once), then create runtimes from it:
 
 ```javascript
-import { initXript } from "@xript/runtime-js";
+import { initXript } from "@xript/runtime";
 
 const xript = await initXript();
 const runtime = xript.createRuntime(manifest, {
@@ -33,7 +33,7 @@ const runtime = xript.createRuntime(manifest, {
 For applications with async host bindings, use the async variant:
 
 ```javascript
-import { initXriptAsync } from "@xript/runtime-js";
+import { initXriptAsync } from "@xript/runtime";
 
 const xript = await initXriptAsync();
 const runtime = await xript.createRuntime(manifest, {
@@ -129,7 +129,7 @@ The runtime exports four error classes, all available as named imports:
 Thrown when the manifest fails structural validation.
 
 ```javascript
-import { ManifestValidationError } from "@xript/runtime-js";
+import { ManifestValidationError } from "@xript/runtime";
 
 try {
   xript.createRuntime({}, { hostBindings: {} });
@@ -146,7 +146,7 @@ The `issues` array contains every problem found, with a `path` and `message` for
 Thrown when a host function throws or is not provided.
 
 ```javascript
-import { BindingError } from "@xript/runtime-js";
+import { BindingError } from "@xript/runtime";
 // e.name === "BindingError"
 // e.binding === "player.getHealth"
 // e.message includes the original error message
@@ -157,7 +157,7 @@ import { BindingError } from "@xript/runtime-js";
 Thrown when calling a capability-gated binding without the required capability.
 
 ```javascript
-import { CapabilityDeniedError } from "@xript/runtime-js";
+import { CapabilityDeniedError } from "@xript/runtime";
 // e.name === "CapabilityDeniedError"
 // e.capability === "modify-player"
 // e.binding === "player.setHealth"
@@ -168,7 +168,7 @@ import { CapabilityDeniedError } from "@xript/runtime-js";
 Thrown when the script exceeds configured execution limits (timeout, memory).
 
 ```javascript
-import { ExecutionLimitError } from "@xript/runtime-js";
+import { ExecutionLimitError } from "@xript/runtime";
 // e.name === "ExecutionLimitError"
 // e.limit === "timeout_ms"
 ```
@@ -190,7 +190,7 @@ The sandbox provides a restricted JavaScript environment powered by QuickJS comp
 Since the runtime uses QuickJS WASM, it works in browsers without any Node.js-specific APIs:
 
 ```javascript
-import { initXript } from "@xript/runtime-js";
+import { initXript } from "@xript/runtime";
 
 const xript = await initXript();
 const runtime = xript.createRuntime(manifest, { hostBindings });

--- a/docs/src/content/docs/vision.md
+++ b/docs/src/content/docs/vision.md
@@ -72,7 +72,7 @@ The xript manifest is not configuration — it *is* the API. It defines bindings
 - Documentation sites
 - TypeScript definitions
 - Validation rules
-- Interactive playgrounds (planned)
+- Interactive playgrounds
 
 If it's not in the manifest, it doesn't exist. If it is, it's documented, typed, and enforceable.
 

--- a/examples/expression-evaluator/package.json
+++ b/examples/expression-evaluator/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"private": true,
 	"type": "module",
-	"description": "Example: expression evaluator using @xript/runtime-js",
+	"description": "Example: expression evaluator using @xript/runtime",
 	"scripts": {
 		"start": "node src/host.js",
 		"demo": "node src/demo.js"

--- a/examples/plugin-system/package.json
+++ b/examples/plugin-system/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"private": true,
 	"type": "module",
-	"description": "Example: tier 2 plugin system with capabilities using @xript/runtime-js",
+	"description": "Example: tier 2 plugin system with capabilities using @xript/runtime",
 	"scripts": {
 		"demo": "node src/demo.js"
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@astrojs/starlight": "^0.37.6",
 				"@fontsource-variable/inter": "^5.2.8",
 				"@fontsource/jetbrains-mono": "^5.2.8",
-				"@xript/runtime-js": "^0.2.0",
+				"@xript/runtime": "^0.2.0",
 				"astro": "^5.17.1"
 			}
 		},
@@ -1909,7 +1909,7 @@
 			"resolved": "tools/manifest-validator",
 			"link": true
 		},
-		"node_modules/@xript/runtime-js": {
+		"node_modules/@xript/runtime": {
 			"resolved": "runtimes/js",
 			"link": true
 		},
@@ -6583,7 +6583,7 @@
 			}
 		},
 		"runtimes/js": {
-			"name": "@xript/runtime-js",
+			"name": "@xript/runtime",
 			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {

--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -4,7 +4,7 @@ Language-specific implementations of the xript runtime.
 
 ## Available Runtimes
 
-- **js/** (`@xript/runtime-js`) — universal JavaScript runtime using QuickJS compiled to WASM for sandboxed execution (works in browser, Node, Deno, and more)
+- **js/** (`@xript/runtime`) — universal JavaScript runtime using QuickJS compiled to WASM for sandboxed execution (works in browser, Node, Deno, and more)
 - **node/** (`@xript/runtime-node`) — Node.js-optimized runtime using the `vm` module for sandboxed execution (includes `createRuntimeFromFile` and full JSON Schema validation)
 
 ## Planned Runtimes

--- a/runtimes/js/package.json
+++ b/runtimes/js/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@xript/runtime-js",
+	"name": "@xript/runtime",
 	"version": "0.2.0",
 	"description": "Universal JavaScript runtime for xript — QuickJS WASM sandbox for browser, Node, Deno, and more.",
 	"type": "module",

--- a/spec/manifest.md
+++ b/spec/manifest.md
@@ -1,6 +1,6 @@
 # xript Manifest Specification
 
-The xript manifest is the single source of truth for an application's scripting API. It declares what functionality is exposed to scripts, how it is organized, what capabilities gate access, and what types are involved. From the manifest, everything else is derived: documentation, TypeScript definitions, and validation. Interactive playgrounds are planned as a future toolchain output.
+The xript manifest is the single source of truth for an application's scripting API. It declares what functionality is exposed to scripts, how it is organized, what capabilities gate access, and what types are involved. From the manifest, everything else is derived: documentation, TypeScript definitions, and validation. Interactive playgrounds are also supported as a toolchain output.
 
 This document explains the structure of the manifest, the rationale behind key decisions, and how the manifest supports xript's three adoption tiers.
 

--- a/spec/vision.md
+++ b/spec/vision.md
@@ -69,7 +69,7 @@ The xript manifest is not configuration — it *is* the API. It defines bindings
 - Documentation sites
 - TypeScript definitions
 - Validation rules
-- Interactive playgrounds (planned)
+- Interactive playgrounds
 
 If it's not in the manifest, it doesn't exist. If it is, it's documented, typed, and enforceable.
 


### PR DESCRIPTION
## Summary

- renamed `@xript/runtime-js` to `@xript/runtime` across 25 files
- fixed stale "Interactive playgrounds (planned)" references in spec and docs (they exist now)
- corrected doc page counts in README (17 → 19) and CLAUDE.md (20 → 19)
- disabled Astro prefetching (unnecessary for a static docs site)
- updated CI step names to match the new package name

## Test plan

- [x] 163 tests pass across all 6 packages
- [x] all 3 example smoke tests pass
- [x] docs site builds clean (20 pages)
- [x] zero remaining references to `@xript/runtime-js`