### PR TITLE
switch publish workflow to OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,20 +46,14 @@ jobs:
         run: npm test --workspace=runtimes/node
 
       - name: publish validate
-        run: npm publish --workspace=tools/validate        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace=tools/validate
       - name: publish typegen
-        run: npm publish --workspace=tools/typegen        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace=tools/typegen
       - name: publish docgen
-        run: npm publish --workspace=tools/docgen        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace=tools/docgen
       - name: publish init
-        run: npm publish --workspace=tools/init        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace=tools/init
       - name: publish runtime
-        run: npm publish --workspace=runtimes/js        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace=runtimes/js
       - name: publish runtime-node
-        run: npm publish --workspace=runtimes/node        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace=runtimes/node


### PR DESCRIPTION
## Summary
- Removed `NODE_AUTH_TOKEN` env blocks from all 6 publish steps in `publish.yml`
- OIDC trusted publishing is now configured on npmjs.com for all `@xriptjs/*` packages, so no secrets are needed
- The existing `id-token: write` permission + `registry-url` in `setup-node` handles auth automatically

## Test plan
- [ ] Verify workflow YAML is valid (CI passes)
- [ ] Next version bump triggers a successful publish via `workflow_dispatch`