### PR TITLE
restored backronym footnote in vision doc

### DIFF
--- a/docs/src/content/docs/vision.md
+++ b/docs/src/content/docs/vision.md
@@ -151,3 +151,5 @@ xript succeeds when:
 *xript.dev — mod the it*
 
 ---
+
+And before anyone asks, yes, it was backronymed: **eXtensible Runtime Interface Protocol Tooling**, but the 'xr' is real.


### PR DESCRIPTION
## Summary

- Morticia's post-mortem on PR #70 incorrectly removed the intentional backronym footnote from the docs vision page
- This restores the "before anyone asks" line at the bottom of the vision doc

## Test plan

- [x] It's one line of prose