### PR TITLE
npm homepage and patch bumps for republish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4647,7 +4647,7 @@
 		},
 		"runtimes/js": {
 			"name": "@xriptjs/runtime",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"quickjs-emscripten": "^0.31.0"
@@ -4672,7 +4672,7 @@
 		},
 		"runtimes/node": {
 			"name": "@xriptjs/runtime-node",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^22.0.0",
@@ -4694,7 +4694,7 @@
 		},
 		"tools/docgen": {
 			"name": "@xriptjs/docgen",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "MIT",
 			"bin": {
 				"xript-docgen": "dist/cli.js"
@@ -4719,7 +4719,7 @@
 		},
 		"tools/init": {
 			"name": "@xriptjs/init",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "MIT",
 			"bin": {
 				"xript-init": "dist/cli.js"
@@ -4727,7 +4727,7 @@
 		},
 		"tools/typegen": {
 			"name": "@xriptjs/typegen",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "MIT",
 			"bin": {
 				"xript-typegen": "dist/cli.js"
@@ -4752,7 +4752,7 @@
 		},
 		"tools/validate": {
 			"name": "@xriptjs/validate",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.17.1",

--- a/runtimes/js/package.json
+++ b/runtimes/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/runtime",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Universal JavaScript runtime for xript — QuickJS WASM sandbox for browser, Node, Deno, and more.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,6 +17,7 @@
 		"url": "https://github.com/nekoyoubi/xript.git",
 		"directory": "runtimes/js"
 	},
+	"homepage": "https://xript.dev",
 	"scripts": {
 		"build": "tsc",
 		"test": "node --test test/*.test.js",

--- a/runtimes/node/package.json
+++ b/runtimes/node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/runtime-node",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Node.js-optimized xript runtime — sandboxed script execution via Node.js vm module.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,6 +17,7 @@
 		"url": "https://github.com/nekoyoubi/xript.git",
 		"directory": "runtimes/node"
 	},
+	"homepage": "https://xript.dev",
 	"scripts": {
 		"build": "tsc",
 		"test": "node --test test/*.test.js",

--- a/tools/docgen/package.json
+++ b/tools/docgen/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/docgen",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Generate documentation from xript manifests.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,6 +17,7 @@
 		"url": "https://github.com/nekoyoubi/xript.git",
 		"directory": "tools/docgen"
 	},
+	"homepage": "https://xript.dev",
 	"bin": {
 		"xript-docgen": "./dist/cli.js"
 	},

--- a/tools/init/package.json
+++ b/tools/init/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/init",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Scaffolding CLI for new xript projects.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,6 +17,7 @@
 		"url": "https://github.com/nekoyoubi/xript.git",
 		"directory": "tools/init"
 	},
+	"homepage": "https://xript.dev",
 	"bin": {
 		"xript-init": "./dist/cli.js"
 	},

--- a/tools/typegen/package.json
+++ b/tools/typegen/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/typegen",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Generate TypeScript definitions from xript manifests.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,6 +17,7 @@
 		"url": "https://github.com/nekoyoubi/xript.git",
 		"directory": "tools/typegen"
 	},
+	"homepage": "https://xript.dev",
 	"bin": {
 		"xript-typegen": "./dist/cli.js"
 	},

--- a/tools/validate/package.json
+++ b/tools/validate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/validate",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Validate xript manifests against the specification schema.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,6 +17,7 @@
 		"url": "https://github.com/nekoyoubi/xript.git",
 		"directory": "tools/validate"
 	},
+	"homepage": "https://xript.dev",
 	"bin": {
 		"xript-validate": "./dist/cli.js"
 	},


### PR DESCRIPTION
## Summary
- added `"homepage": "https://xript.dev"` to all 6 npm packages so npm shows xript.dev as the website link instead of the GitHub repo URL
- patch-bumped all 6 packages to enable republishing with updated READMEs and metadata

| Package | Old | New |
|---------|-----|-----|
| `@xriptjs/runtime` | 0.2.0 | 0.2.1 |
| `@xriptjs/runtime-node` | 0.1.0 | 0.1.1 |
| `@xriptjs/validate` | 0.1.0 | 0.1.1 |
| `@xriptjs/typegen` | 0.1.0 | 0.1.1 |
| `@xriptjs/docgen` | 0.1.0 | 0.1.1 |
| `@xriptjs/init` | 0.1.0 | 0.1.1 |

## Test plan
- [ ] `npm install` succeeds with no errors
- [ ] each package.json contains `"homepage": "https://xript.dev"`
- [ ] version bumps are consistent across all packages and lockfile
- [ ] after merge, publish workflow can be triggered to push updated packages to npm