### PR TITLE
added --allow-dirty to crates.io publish

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -13,12 +13,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: publish xript-runtime
-        run: cargo publish --manifest-path runtimes/rust/Cargo.toml
+        run: cargo publish --allow-dirty --manifest-path runtimes/rust/Cargo.toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
       - name: publish xript-ratatui
-        run: cargo publish --manifest-path renderers/ratatui/Cargo.toml
+        run: cargo publish --allow-dirty --manifest-path renderers/ratatui/Cargo.toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
@@ -26,6 +26,6 @@ jobs:
         run: sleep 60
 
       - name: publish xript-wiz
-        run: cargo publish --manifest-path tools/wiz/Cargo.toml
+        run: cargo publish --allow-dirty --manifest-path tools/wiz/Cargo.toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## Summary
- `Cargo.lock` is generated during CI but not committed (standard for library crates), so `cargo publish` rejects it
- Added `--allow-dirty` to all three publish steps

## Test plan
- [x] CI passes
- [x] Re-run the crates.io publish workflow manually after merge