### PR TITLE
v0.4.2 — sanitizer + Rust runtime fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## v0.4.2 — TBD
+
 ## v0.4.1 — npm housekeeping
 
 - added a README for `@xriptjs/cli` so the npm package page isn't a blank stare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Changelog
 
-## v0.4.2 — TBD
+## v0.4.2 — Sanitizer + Rust Runtime Fixes
+
+- expanded the sanitizer's allowed element list across all four implementations (TypeScript, Rust/ammonia, C#)
+  - added `button`, `progress`, `meter`, `output`, `fieldset`, and `legend`; `button` was the big miss since it's the primary element for `data-action` event handlers in fragments
+  - added 14 SVG elements: `svg`, `g`, `defs`, `symbol`, `use`, `circle`, `ellipse`, `path`, `rect`, `line`, `polygon`, `polyline`, `text`, `tspan` for icons and data visualization in mod UIs
+  - added `foreignObject`, `animate`, and `set` to the stripped elements list (dangerous SVG elements that shouldn't survive sanitization)
+- added missing attributes: `open` for `<details>`, `low`/`high`/`optimum` for `<meter>`, plus 18 SVG attributes covering geometry and presentation
+- fixed SVG attribute casing; `viewBox` and `preserveAspectRatio` were being lowercased by the tokenizer, which silently breaks SVG rendering in browsers
+- updated the fragment spec documentation in `fragments.md` with the new element and attribute lists
+- added 11 new conformance test cases to `spec/sanitizer-tests.json` and 11 new unit tests across the implementations
+- fixed a serialization bug in `xript-runtime` (Rust) where `js_value_to_json` silently returned `Null` for objects and arrays from `execute()` (#89)
+  - the fallback code evaluated `((v) => JSON.stringify(v))` which returned the function's _string representation_ instead of actually calling it with the value
+  - replaced the broken eval with a proper `Function::call` through rquickjs's API
+  - added 3 new tests for object, array, and nested object serialization
+
+### Test counts
+
+| package | v0.4.1 | v0.4.2 |
+|---------|--------|--------|
+| `@xriptjs/sanitize` | 71 | 93 |
+| `@xriptjs/validate` | 25 | 25 |
+| `@xriptjs/typegen` | 31 | 31 |
+| `@xriptjs/docgen` | 28 | 28 |
+| `@xriptjs/init` | 34 | 34 |
+| `@xriptjs/cli` | 29 | 29 |
+| `@xriptjs/runtime` | 97 | 97 |
+| `@xriptjs/runtime-node` | 97 | 97 |
+| `xript-runtime` (Rust) | 45 | 48 |
+| `xript-ratatui` | 58 | 58 |
+| `xript-wiz` | 35 | 35 |
+| `Xript.Runtime` (C#) | 116 | 116 |
+| **total** | **666** | **691** |
 
 ## v0.4.1 — npm housekeeping
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,18 +126,18 @@ A top-level `CHANGELOG.md` tracks all releases. Follow these rules:
 
 ## Current State
 
-v0.4 shipped — Unified CLI, Annotation Scanning, Fragment Workbench (666 tests across 12 packages):
+v0.4.2 shipped — Sanitizer + Rust Runtime Fixes (691 tests across 12 packages):
 
-- **Spec v0.3**: manifest schema extended with `slots`, new mod manifest schema (`spec/mod-manifest.schema.json`), fragment protocol specification (`spec/fragments.md`), fragment format catalog (`spec/fragment-formats.md`), HTML sanitizer conformance suite (`spec/sanitizer-tests.json`, 45 test cases)
-- **HTML Sanitizer**: `@xriptjs/sanitize` in `tools/sanitize/` -- pure string-based HTML+JSML sanitizer with no DOM dependency (works in QuickJS WASM), 71 tests
+- **Spec v0.3**: manifest schema extended with `slots`, new mod manifest schema (`spec/mod-manifest.schema.json`), fragment protocol specification (`spec/fragments.md`), fragment format catalog (`spec/fragment-formats.md`), HTML sanitizer conformance suite (`spec/sanitizer-tests.json`, 56 test cases)
+- **HTML Sanitizer**: `@xriptjs/sanitize` in `tools/sanitize/` -- pure string-based HTML+JSML sanitizer with no DOM dependency (works in QuickJS WASM), SVG support (14 elements, dangerous SVG stripping), 93 tests
 - **Universal Runtime**: `@xriptjs/runtime` in `runtimes/js/` -- QuickJS WASM sandbox with capability enforcement, hook system, `loadMod()`, fragment processing (`data-bind`, `data-if`), JSML support, sandbox fragment API (command buffer pattern), 97 tests
 - **Node.js Runtime**: `@xriptjs/runtime-node` in `runtimes/node/` -- Node.js vm-based sandbox with full fragment support, 97 tests
-- **Rust Runtime**: `xript-runtime` in `runtimes/rust/` -- native QuickJS sandbox via rquickjs with host bindings (sync and async), capability enforcement, hooks, resource limits, `load_mod()` with entry script execution, fragment processing, `XriptHandle` Send+Sync wrapper, 45 tests
+- **Rust Runtime**: `xript-runtime` in `runtimes/rust/` -- native QuickJS sandbox via rquickjs with host bindings (sync and async), capability enforcement, hooks, resource limits, `load_mod()` with entry script execution, fragment processing, `XriptHandle` Send+Sync wrapper, 48 tests
 - **C# Runtime**: `Xript.Runtime` in `runtimes/csharp/` -- Jint sandbox with host bindings, capability enforcement, hooks, resource limits, `LoadMod()`, fragment processing, 116 tests
 - **Ratatui Renderer**: `xript-ratatui` in `renderers/ratatui/` -- fragment renderer for Ratatui terminal apps, parses `application/x-ratatui+json` into native widgets, 58 tests
 - **TUI Wizard**: `xript-wiz` in `tools/wiz/` -- interactive TUI wizard that dogfoods the xript ecosystem (fragments rendered by `xript-ratatui`), audit and diff screens for manifest analysis, 35 tests
 - **Unified CLI**: `@xriptjs/cli` in `tools/cli/` -- single `xript` command with subcommands for validate, typegen, docgen, init, sanitize, and scan (annotation scanning), 29 tests
-- **Toolchain**: manifest validator (app + mod, auto-detection, cross-validation, 25 tests), type generator (slot + fragment API types, 31 tests), doc generator (slot docs + fragment API page + `--link-format` + `--frontmatter`, 28 tests), init CLI (app + mod scaffolding + tier 4 full feature, 34 tests), sanitizer (71 tests)
+- **Toolchain**: manifest validator (app + mod, auto-detection, cross-validation, 25 tests), type generator (slot + fragment API types, 31 tests), doc generator (slot docs + fragment API page + `--link-format` + `--frontmatter`, 28 tests), init CLI (app + mod scaffolding + tier 4 full feature, 34 tests), sanitizer (93 tests)
 - **Annotation Scanning**: `spec/annotations.md` defines `@xript` and `@xript-cap` JSDoc tags; `xript scan` reads TypeScript source and generates manifest bindings/capabilities
 - **Examples**: four examples including `ui-dashboard/` demonstrating the full fragment protocol (slots, mod manifests, `data-bind`, `data-if`, sandbox fragment API)
 - **Developer Experience**: docs site at xript.dev (29 pages), getting started guide, runtime API reference, runtime overview comparison, four example walkthroughs, interactive hero playground with live simulations, four interactive live demos including Fragment Builder, Fragment Workbench interactive tool

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,8 +12,8 @@
 		"@astrojs/starlight": "0.37.6",
 		"@fontsource-variable/inter": "^5.2.8",
 		"@fontsource/jetbrains-mono": "^5.2.8",
-		"@xriptjs/runtime": "^0.4.1",
-		"@xriptjs/sanitize": "^0.4.1",
+		"@xriptjs/runtime": "^0.4.2",
+		"@xriptjs/sanitize": "^0.4.2",
 		"astro": "5.17.2",
 		"codejar": "^4.3.0",
 		"zod": "3.24.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "xript",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "xript",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"workspaces": [
 				"docs",
 				"runtimes/*",
@@ -20,8 +20,8 @@
 				"@astrojs/starlight": "0.37.6",
 				"@fontsource-variable/inter": "^5.2.8",
 				"@fontsource/jetbrains-mono": "^5.2.8",
-				"@xriptjs/runtime": "^0.4.1",
-				"@xriptjs/sanitize": "^0.4.1",
+				"@xriptjs/runtime": "^0.4.2",
+				"@xriptjs/sanitize": "^0.4.2",
 				"astro": "5.17.2",
 				"codejar": "^4.3.0",
 				"zod": "3.24.4"
@@ -4986,10 +4986,10 @@
 		},
 		"runtimes/js": {
 			"name": "@xriptjs/runtime",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MIT",
 			"dependencies": {
-				"@xriptjs/sanitize": "^0.4.1",
+				"@xriptjs/sanitize": "^0.4.2",
 				"quickjs-emscripten": "^0.31.0"
 			},
 			"devDependencies": {
@@ -5012,10 +5012,10 @@
 		},
 		"runtimes/node": {
 			"name": "@xriptjs/runtime-node",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MIT",
 			"dependencies": {
-				"@xriptjs/sanitize": "^0.4.1"
+				"@xriptjs/sanitize": "^0.4.2"
 			},
 			"devDependencies": {
 				"@types/node": "^22.0.0",
@@ -5037,14 +5037,14 @@
 		},
 		"tools/cli": {
 			"name": "@xriptjs/cli",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MIT",
 			"dependencies": {
-				"@xriptjs/docgen": "^0.4.1",
-				"@xriptjs/init": "^0.4.1",
-				"@xriptjs/sanitize": "^0.4.1",
-				"@xriptjs/typegen": "^0.4.1",
-				"@xriptjs/validate": "^0.4.1"
+				"@xriptjs/docgen": "^0.4.2",
+				"@xriptjs/init": "^0.4.2",
+				"@xriptjs/sanitize": "^0.4.2",
+				"@xriptjs/typegen": "^0.4.2",
+				"@xriptjs/validate": "^0.4.2"
 			},
 			"bin": {
 				"xript": "dist/cli.js"
@@ -5076,7 +5076,7 @@
 		},
 		"tools/docgen": {
 			"name": "@xriptjs/docgen",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^22.0.0",
@@ -5098,12 +5098,12 @@
 		},
 		"tools/init": {
 			"name": "@xriptjs/init",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MIT"
 		},
 		"tools/sanitize": {
 			"name": "@xriptjs/sanitize",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^22.0.0",
@@ -5129,7 +5129,7 @@
 		},
 		"tools/typegen": {
 			"name": "@xriptjs/typegen",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^22.0.0",
@@ -5151,7 +5151,7 @@
 		},
 		"tools/validate": {
 			"name": "@xriptjs/validate",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "xript",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"private": true,
 	"workspaces": [
 		"docs",

--- a/renderers/ratatui/Cargo.toml
+++ b/renderers/ratatui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xript-ratatui"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Fragment renderer for Ratatui terminal applications — renders xript UI fragments as terminal widgets."
 license = "MIT"
@@ -16,5 +16,5 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-xript-runtime = { version = "0.4.1", path = "../../runtimes/rust" }
+xript-runtime = { version = "0.4.2", path = "../../runtimes/rust" }
 crossterm = "0.28"

--- a/runtimes/csharp/src/Xript.Runtime/FragmentProcessor.cs
+++ b/runtimes/csharp/src/Xript.Runtime/FragmentProcessor.cs
@@ -276,7 +276,7 @@ public sealed class FragmentProcessor
     }
 
     private static readonly string[] StrippedElementNames =
-        ["script", "iframe", "object", "embed", "form", "base", "link", "meta", "title", "noscript", "applet", "frame", "frameset", "param"];
+        ["script", "iframe", "object", "embed", "form", "base", "link", "meta", "title", "noscript", "applet", "frame", "frameset", "param", "foreignobject", "animate", "set"];
 
     private static string StripElements(string html)
     {

--- a/runtimes/csharp/src/Xript.Runtime/Xript.Runtime.csproj
+++ b/runtimes/csharp/src/Xript.Runtime/Xript.Runtime.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Xript.Runtime</RootNamespace>
 
     <PackageId>Xript.Runtime</PackageId>
-    <Version>0.4.1</Version>
+    <Version>0.4.2</Version>
     <Authors>nekoyoubi</Authors>
     <Description>C# runtime for xript — sandboxed JavaScript execution via Jint with manifest-driven bindings and capability enforcement.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/runtimes/js/package.json
+++ b/runtimes/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/runtime",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Universal JavaScript runtime for xript — QuickJS WASM sandbox for browser, Node, Deno, and more.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"quickjs-emscripten": "^0.31.0",
-		"@xriptjs/sanitize": "^0.4.1"
+		"@xriptjs/sanitize": "^0.4.2"
 	},
 	"devDependencies": {
 		"typescript": "^5.7.0",

--- a/runtimes/node/package.json
+++ b/runtimes/node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/runtime-node",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Node.js-optimized xript runtime — sandboxed script execution via Node.js vm module.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -40,7 +40,7 @@
 		"provenance": true
 	},
 	"dependencies": {
-		"@xriptjs/sanitize": "^0.4.1"
+		"@xriptjs/sanitize": "^0.4.2"
 	},
 	"devDependencies": {
 		"typescript": "^5.7.0",

--- a/runtimes/rust/Cargo.lock
+++ b/runtimes/rust/Cargo.lock
@@ -769,7 +769,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xript-runtime"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "ammonia",
  "pollster",

--- a/runtimes/rust/Cargo.toml
+++ b/runtimes/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xript-runtime"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Rust runtime for xript. Sandboxed JavaScript execution via QuickJS."
 license = "MIT"

--- a/runtimes/rust/src/fragment.rs
+++ b/runtimes/rust/src/fragment.rs
@@ -28,6 +28,10 @@ pub fn sanitize_html(input: &str) -> String {
         "a", "abbr", "mark", "time", "wbr",
         "style",
         "input", "textarea", "select", "option", "label",
+        "button", "progress", "meter", "output", "fieldset", "legend",
+        "svg", "g", "defs", "symbol", "use",
+        "circle", "ellipse", "path", "rect", "line", "polygon", "polyline",
+        "text", "tspan",
     ].into_iter().collect();
 
     let stripped_tags: HashSet<&str> = [
@@ -35,6 +39,7 @@ pub fn sanitize_html(input: &str) -> String {
         "base", "link", "meta", "title",
         "noscript", "applet", "frame", "frameset",
         "param",
+        "foreignobject", "animate", "set",
     ].into_iter().collect();
 
     builder.tags(allowed_tags);
@@ -91,6 +96,81 @@ pub fn sanitize_html(input: &str) -> String {
     tag_attrs.insert("track", {
         let mut s: HashSet<&str> = HashSet::new();
         s.insert("src");
+        s
+    });
+
+    let button_attrs: HashSet<&str> = ["type", "disabled", "name", "value"].into_iter().collect();
+    tag_attrs.insert("button", button_attrs);
+
+    let progress_attrs: HashSet<&str> = ["value", "max"].into_iter().collect();
+    tag_attrs.insert("progress", progress_attrs);
+
+    let meter_attrs: HashSet<&str> = ["value", "min", "max", "low", "high", "optimum"].into_iter().collect();
+    tag_attrs.insert("meter", meter_attrs);
+
+    let output_attrs: HashSet<&str> = ["for", "name"].into_iter().collect();
+    tag_attrs.insert("output", output_attrs);
+
+    let fieldset_attrs: HashSet<&str> = ["disabled", "name"].into_iter().collect();
+    tag_attrs.insert("fieldset", fieldset_attrs);
+
+    tag_attrs.insert("details", {
+        let mut s = HashSet::new();
+        s.insert("open");
+        s
+    });
+
+    let svg_presentation: HashSet<&str> = [
+        "fill", "stroke", "stroke-width", "opacity", "transform",
+    ].into_iter().collect();
+
+    let svg_attrs: HashSet<&str> = [
+        "viewBox", "preserveAspectRatio", "xmlns",
+        "fill", "stroke", "stroke-width", "opacity", "transform",
+    ].into_iter().collect();
+    tag_attrs.insert("svg", svg_attrs);
+
+    let circle_attrs: HashSet<&str> = ["cx", "cy", "r"].into_iter().collect::<HashSet<_>>()
+        .union(&svg_presentation).copied().collect();
+    tag_attrs.insert("circle", circle_attrs);
+
+    let ellipse_attrs: HashSet<&str> = ["cx", "cy", "rx", "ry"].into_iter().collect::<HashSet<_>>()
+        .union(&svg_presentation).copied().collect();
+    tag_attrs.insert("ellipse", ellipse_attrs);
+
+    let rect_attrs: HashSet<&str> = ["x", "y", "width", "height", "rx", "ry"].into_iter().collect::<HashSet<_>>()
+        .union(&svg_presentation).copied().collect();
+    tag_attrs.insert("rect", rect_attrs);
+
+    let line_attrs: HashSet<&str> = ["x1", "y1", "x2", "y2"].into_iter().collect::<HashSet<_>>()
+        .union(&svg_presentation).copied().collect();
+    tag_attrs.insert("line", line_attrs);
+
+    let path_attrs: HashSet<&str> = ["d"].into_iter().collect::<HashSet<_>>()
+        .union(&svg_presentation).copied().collect();
+    tag_attrs.insert("path", path_attrs);
+
+    let polygon_attrs: HashSet<&str> = ["points"].into_iter().collect::<HashSet<_>>()
+        .union(&svg_presentation).copied().collect();
+    tag_attrs.insert("polygon", polygon_attrs.clone());
+    tag_attrs.insert("polyline", polygon_attrs);
+
+    let text_svg_attrs: HashSet<&str> = ["x", "y"].into_iter().collect::<HashSet<_>>()
+        .union(&svg_presentation).copied().collect();
+    tag_attrs.insert("text", text_svg_attrs.clone());
+    tag_attrs.insert("tspan", text_svg_attrs);
+
+    for tag in ["g", "defs", "symbol", "use"] {
+        tag_attrs.insert(tag, svg_presentation.clone());
+    }
+
+    tag_attrs.insert("use", {
+        let mut s = svg_presentation.clone();
+        s.insert("href");
+        s.insert("x");
+        s.insert("y");
+        s.insert("width");
+        s.insert("height");
         s
     });
 

--- a/runtimes/rust/src/fragment.rs
+++ b/runtimes/rust/src/fragment.rs
@@ -114,15 +114,16 @@ pub fn sanitize_html(input: &str) -> String {
     let fieldset_attrs: HashSet<&str> = ["disabled", "name"].into_iter().collect();
     tag_attrs.insert("fieldset", fieldset_attrs);
 
-    tag_attrs.insert("details", {
-        let mut s = HashSet::new();
-        s.insert("open");
-        s
-    });
+    let details_attrs: HashSet<&str> = ["open"].into_iter().collect();
+    tag_attrs.insert("details", details_attrs);
 
     let svg_presentation: HashSet<&str> = [
         "fill", "stroke", "stroke-width", "opacity", "transform",
     ].into_iter().collect();
+
+    let with_presentation = |extra: &[&'static str]| -> HashSet<&str> {
+        extra.iter().copied().chain(svg_presentation.iter().copied()).collect()
+    };
 
     let svg_attrs: HashSet<&str> = [
         "viewBox", "preserveAspectRatio", "xmlns",
@@ -130,49 +131,21 @@ pub fn sanitize_html(input: &str) -> String {
     ].into_iter().collect();
     tag_attrs.insert("svg", svg_attrs);
 
-    let circle_attrs: HashSet<&str> = ["cx", "cy", "r"].into_iter().collect::<HashSet<_>>()
-        .union(&svg_presentation).copied().collect();
-    tag_attrs.insert("circle", circle_attrs);
+    tag_attrs.insert("circle",   with_presentation(&["cx", "cy", "r"]));
+    tag_attrs.insert("ellipse",  with_presentation(&["cx", "cy", "rx", "ry"]));
+    tag_attrs.insert("rect",     with_presentation(&["x", "y", "width", "height", "rx", "ry"]));
+    tag_attrs.insert("line",     with_presentation(&["x1", "y1", "x2", "y2"]));
+    tag_attrs.insert("path",     with_presentation(&["d"]));
+    tag_attrs.insert("polygon",  with_presentation(&["points"]));
+    tag_attrs.insert("polyline", with_presentation(&["points"]));
+    tag_attrs.insert("text",     with_presentation(&["x", "y"]));
+    tag_attrs.insert("tspan",    with_presentation(&["x", "y"]));
 
-    let ellipse_attrs: HashSet<&str> = ["cx", "cy", "rx", "ry"].into_iter().collect::<HashSet<_>>()
-        .union(&svg_presentation).copied().collect();
-    tag_attrs.insert("ellipse", ellipse_attrs);
-
-    let rect_attrs: HashSet<&str> = ["x", "y", "width", "height", "rx", "ry"].into_iter().collect::<HashSet<_>>()
-        .union(&svg_presentation).copied().collect();
-    tag_attrs.insert("rect", rect_attrs);
-
-    let line_attrs: HashSet<&str> = ["x1", "y1", "x2", "y2"].into_iter().collect::<HashSet<_>>()
-        .union(&svg_presentation).copied().collect();
-    tag_attrs.insert("line", line_attrs);
-
-    let path_attrs: HashSet<&str> = ["d"].into_iter().collect::<HashSet<_>>()
-        .union(&svg_presentation).copied().collect();
-    tag_attrs.insert("path", path_attrs);
-
-    let polygon_attrs: HashSet<&str> = ["points"].into_iter().collect::<HashSet<_>>()
-        .union(&svg_presentation).copied().collect();
-    tag_attrs.insert("polygon", polygon_attrs.clone());
-    tag_attrs.insert("polyline", polygon_attrs);
-
-    let text_svg_attrs: HashSet<&str> = ["x", "y"].into_iter().collect::<HashSet<_>>()
-        .union(&svg_presentation).copied().collect();
-    tag_attrs.insert("text", text_svg_attrs.clone());
-    tag_attrs.insert("tspan", text_svg_attrs);
-
-    for tag in ["g", "defs", "symbol", "use"] {
+    for tag in ["g", "defs", "symbol"] {
         tag_attrs.insert(tag, svg_presentation.clone());
     }
 
-    tag_attrs.insert("use", {
-        let mut s = svg_presentation.clone();
-        s.insert("href");
-        s.insert("x");
-        s.insert("y");
-        s.insert("width");
-        s.insert("height");
-        s
-    });
+    tag_attrs.insert("use", with_presentation(&["href", "x", "y", "width", "height"]));
 
     builder.tag_attributes(tag_attrs);
 

--- a/runtimes/rust/src/lib.rs
+++ b/runtimes/rust/src/lib.rs
@@ -142,6 +142,54 @@ mod tests {
     }
 
     #[test]
+    fn returns_object_from_execute() {
+        let rt = create_runtime(
+            minimal_manifest(),
+            RuntimeOptions {
+                host_bindings: HostBindings::new(),
+                capabilities: vec![],
+                console: ConsoleHandler::default(),
+            },
+        )
+        .unwrap();
+
+        let result = rt.execute("({ a: 1, b: [2, 3] })").unwrap();
+        assert_eq!(result.value, serde_json::json!({"a": 1, "b": [2, 3]}));
+    }
+
+    #[test]
+    fn returns_array_from_execute() {
+        let rt = create_runtime(
+            minimal_manifest(),
+            RuntimeOptions {
+                host_bindings: HostBindings::new(),
+                capabilities: vec![],
+                console: ConsoleHandler::default(),
+            },
+        )
+        .unwrap();
+
+        let result = rt.execute("[1, 2, 3]").unwrap();
+        assert_eq!(result.value, serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn returns_nested_object_from_execute() {
+        let rt = create_runtime(
+            minimal_manifest(),
+            RuntimeOptions {
+                host_bindings: HostBindings::new(),
+                capabilities: vec![],
+                console: ConsoleHandler::default(),
+            },
+        )
+        .unwrap();
+
+        let result = rt.execute("({ x: { y: 1 }, z: [true, null] })").unwrap();
+        assert_eq!(result.value, serde_json::json!({"x": {"y": 1}, "z": [true, null]}));
+    }
+
+    #[test]
     fn blocks_eval() {
         let rt = create_runtime(
             minimal_manifest(),

--- a/runtimes/rust/src/sandbox.rs
+++ b/runtimes/rust/src/sandbox.rs
@@ -726,7 +726,7 @@ fn resolve_if_promise<'js>(ctx: &Ctx<'js>, val: Value<'js>) -> Value<'js> {
     }
 }
 
-fn js_value_to_json(ctx: &Ctx<'_>, val: &Value<'_>) -> serde_json::Value {
+fn js_value_to_json<'a>(ctx: &Ctx<'a>, val: &Value<'a>) -> serde_json::Value {
     if val.is_undefined() || val.is_null() {
         return serde_json::Value::Null;
     }
@@ -752,12 +752,16 @@ fn js_value_to_json(ctx: &Ctx<'_>, val: &Value<'_>) -> serde_json::Value {
         }
     }
 
-    let stringify_result: std::result::Result<String, _> = ctx.eval(
-        "((v) => JSON.stringify(v))",
-    );
-    if let Ok(stringify_fn_str) = stringify_result {
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&stringify_fn_str) {
-            return v;
+    let json_global: std::result::Result<Object, _> = ctx.globals().get("JSON");
+    if let Ok(json_obj) = json_global {
+        let stringify: std::result::Result<Function, _> = json_obj.get("stringify");
+        if let Ok(func) = stringify {
+            let result: std::result::Result<String, _> = func.call((val.clone(),));
+            if let Ok(json_str) = result {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&json_str) {
+                    return v;
+                }
+            }
         }
     }
 

--- a/spec/fragments.md
+++ b/spec/fragments.md
@@ -254,13 +254,21 @@ For `text/html` fragments, the runtime sanitizes content before the host ever se
 
 Structural and presentational elements: `div`, `span`, `p`, `h1`-`h6`, `ul`, `ol`, `li`, `dl`, `dt`, `dd`, `table`, `thead`, `tbody`, `tfoot`, `tr`, `td`, `th`, `caption`, `col`, `colgroup`, `figure`, `figcaption`, `blockquote`, `pre`, `code`, `em`, `strong`, `b`, `i`, `u`, `s`, `small`, `sub`, `sup`, `br`, `hr`, `img`, `picture`, `source`, `audio`, `video`, `track`, `details`, `summary`, `section`, `article`, `aside`, `nav`, `header`, `footer`, `main`, `a`, `abbr`, `mark`, `time`, `wbr`, `style` (scoped).
 
+Interactive and form elements: `button`, `input`, `textarea`, `select`, `option`, `label`, `fieldset`, `legend`, `progress`, `meter`, `output`.
+
+SVG elements: `svg`, `g`, `defs`, `symbol`, `use`, `circle`, `ellipse`, `path`, `rect`, `line`, `polygon`, `polyline`, `text`, `tspan`.
+
 ### Stripped Elements
 
-Removed entirely (element and all children): `script`, `iframe`, `object`, `embed`, `form`, `base`, `link`, `meta`, `title`, `html`, `head`, `body`, `noscript`, `applet`, `frame`, `frameset`.
+Removed entirely (element and all children): `script`, `iframe`, `object`, `embed`, `form`, `base`, `link`, `meta`, `title`, `html`, `head`, `body`, `noscript`, `applet`, `frame`, `frameset`, `foreignObject`, `animate`, `set`.
 
 ### Allowed Attributes
 
 `class`, `id`, `data-*`, `aria-*`, `role`, `style`, `src` (safe URIs only), `alt`, `width`, `height`, `href` (safe URIs only), `target`, `rel`, `colspan`, `rowspan`, `scope`, `headers`, `lang`, `dir`, `title`, `tabindex`, `hidden`.
+
+Form attributes: `type`, `value`, `placeholder`, `name`, `for`, `checked`, `disabled`, `readonly`, `required`, `rows`, `cols`, `maxlength`, `minlength`, `min`, `max`, `step`, `pattern`, `open`, `low`, `high`, `optimum`.
+
+SVG attributes: `cx`, `cy`, `r`, `x`, `y`, `x1`, `y1`, `x2`, `y2`, `points`, `d`, `fill`, `stroke`, `stroke-width`, `opacity`, `transform`, `viewBox`, `preserveAspectRatio`, `xmlns`.
 
 ### Stripped Attributes
 

--- a/spec/sanitizer-tests.json
+++ b/spec/sanitizer-tests.json
@@ -223,5 +223,60 @@
 		"input": "<a href=\"data:text/html,<script>alert(1)</script>\">click</a>",
 		"expected": "<a>click</a>",
 		"description": "strips data: URI on href attribute"
+	},
+	{
+		"input": "<button data-action=\"heal\" class=\"btn\">Heal</button>",
+		"expected": "<button data-action=\"heal\" class=\"btn\">Heal</button>",
+		"description": "preserves button element with data-action"
+	},
+	{
+		"input": "<progress value=\"70\" max=\"100\">70%</progress>",
+		"expected": "<progress value=\"70\" max=\"100\">70%</progress>",
+		"description": "preserves progress element with value and max"
+	},
+	{
+		"input": "<meter value=\"0.6\" low=\"0.3\" high=\"0.8\" optimum=\"0.5\">60%</meter>",
+		"expected": "<meter value=\"0.6\" low=\"0.3\" high=\"0.8\" optimum=\"0.5\">60%</meter>",
+		"description": "preserves meter element with low, high, and optimum"
+	},
+	{
+		"input": "<fieldset><legend>Settings</legend><input type=\"text\" /></fieldset>",
+		"expected": "<fieldset><legend>Settings</legend><input type=\"text\" /></fieldset>",
+		"description": "preserves fieldset and legend elements"
+	},
+	{
+		"input": "<output name=\"result\">42</output>",
+		"expected": "<output name=\"result\">42</output>",
+		"description": "preserves output element"
+	},
+	{
+		"input": "<details open><summary>Info</summary><p>Details here</p></details>",
+		"expected": "<details open><summary>Info</summary><p>Details here</p></details>",
+		"description": "preserves details element with open attribute"
+	},
+	{
+		"input": "<svg viewBox=\"0 0 100 100\"><circle cx=\"50\" cy=\"50\" r=\"40\" fill=\"red\" /></svg>",
+		"expected": "<svg viewBox=\"0 0 100 100\"><circle cx=\"50\" cy=\"50\" r=\"40\" fill=\"red\" /></svg>",
+		"description": "preserves SVG elements and attributes with correct viewBox casing"
+	},
+	{
+		"input": "<svg><path d=\"M10 10 L90 90\" stroke=\"black\" stroke-width=\"2\" /></svg>",
+		"expected": "<svg><path d=\"M10 10 L90 90\" stroke=\"black\" stroke-width=\"2\" /></svg>",
+		"description": "preserves SVG path with d attribute and stroke properties"
+	},
+	{
+		"input": "<svg preserveAspectRatio=\"xMidYMid meet\"><rect x=\"0\" y=\"0\" width=\"100\" height=\"100\" /></svg>",
+		"expected": "<svg preserveAspectRatio=\"xMidYMid meet\"><rect x=\"0\" y=\"0\" width=\"100\" height=\"100\" /></svg>",
+		"description": "preserves preserveAspectRatio with correct casing"
+	},
+	{
+		"input": "<svg><foreignObject><div>escape</div></foreignObject></svg>",
+		"expected": "<svg></svg>",
+		"description": "strips foreignObject and its children from SVG"
+	},
+	{
+		"input": "<svg><animate attributeName=\"x\" from=\"0\" to=\"100\" /></svg>",
+		"expected": "<svg></svg>",
+		"description": "strips animate element from SVG"
 	}
 ]

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/cli",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Unified CLI for the xript ecosystem — validate, generate types, generate docs, scaffold projects, sanitize fragments, and scan annotations.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -41,11 +41,11 @@
 		"provenance": true
 	},
 	"dependencies": {
-		"@xriptjs/validate": "^0.4.1",
-		"@xriptjs/typegen": "^0.4.1",
-		"@xriptjs/docgen": "^0.4.1",
-		"@xriptjs/init": "^0.4.1",
-		"@xriptjs/sanitize": "^0.4.1"
+		"@xriptjs/validate": "^0.4.2",
+		"@xriptjs/typegen": "^0.4.2",
+		"@xriptjs/docgen": "^0.4.2",
+		"@xriptjs/init": "^0.4.2",
+		"@xriptjs/sanitize": "^0.4.2"
 	},
 	"optionalDependencies": {
 		"ts-morph": "^25.0.0"

--- a/tools/docgen/package.json
+++ b/tools/docgen/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/docgen",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Generate documentation from xript manifests.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/tools/init/package.json
+++ b/tools/init/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/init",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Scaffolding CLI for new xript projects.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/tools/sanitize/package.json
+++ b/tools/sanitize/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/sanitize",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "HTML sanitizer for xript UI fragments. Pure string-based — no DOM dependency.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/tools/sanitize/src/index.ts
+++ b/tools/sanitize/src/index.ts
@@ -6,6 +6,7 @@ import {
 	UNWRAPPED_ELEMENTS,
 	VOID_ELEMENTS,
 	isAllowedAttribute,
+	canonicalAttributeName,
 	sanitizeUri,
 	sanitizeStyleValue,
 	sanitizeStyleBlock,
@@ -160,7 +161,7 @@ function sanitizeAttributes(
 			continue;
 		}
 
-		result.push({ name: lowerName, value: attr.value });
+		result.push({ name: canonicalAttributeName(lowerName), value: attr.value });
 	}
 
 	return result;

--- a/tools/sanitize/src/jsml.ts
+++ b/tools/sanitize/src/jsml.ts
@@ -3,6 +3,7 @@ import {
 	STRIPPED_ELEMENTS,
 	VOID_ELEMENTS,
 	isAllowedAttribute,
+	canonicalAttributeName,
 	sanitizeUri,
 	sanitizeStyleValue,
 } from "./rules.js";
@@ -122,7 +123,7 @@ function sanitizeNodes(
 				continue;
 			}
 
-			cleanAttrs[lowerKey] = val;
+			cleanAttrs[canonicalAttributeName(lowerKey)] = val;
 		}
 
 		const children = node.slice(childStart) as JsmlNode[];

--- a/tools/sanitize/src/rules.ts
+++ b/tools/sanitize/src/rules.ts
@@ -14,6 +14,10 @@ export const ALLOWED_ELEMENTS = new Set([
 	"a", "abbr", "mark", "time", "wbr",
 	"style",
 	"input", "textarea", "select", "option", "label",
+	"button", "progress", "meter", "output", "fieldset", "legend",
+	"svg", "g", "defs", "symbol", "use",
+	"circle", "ellipse", "path", "rect", "line", "polygon", "polyline",
+	"text", "tspan",
 ]);
 
 export const STRIPPED_ELEMENTS = new Set([
@@ -21,6 +25,7 @@ export const STRIPPED_ELEMENTS = new Set([
 	"base", "link", "meta", "title",
 	"noscript", "applet", "frame", "frameset",
 	"param",
+	"foreignobject", "animate", "set",
 ]);
 
 export const UNWRAPPED_ELEMENTS = new Set([
@@ -43,6 +48,10 @@ export const ALLOWED_ATTRIBUTES = new Set([
 	"checked", "disabled", "readonly", "required",
 	"rows", "cols", "maxlength", "minlength",
 	"min", "max", "step", "pattern",
+	"open", "low", "high", "optimum",
+	"cx", "cy", "r", "x", "y", "x1", "y1", "x2", "y2", "points", "d",
+	"fill", "stroke", "stroke-width", "opacity", "transform",
+	"viewbox", "preserveaspectratio", "xmlns",
 ]);
 
 export const DANGEROUS_URI_SCHEMES = /^\s*(javascript|vbscript)\s*:/i;
@@ -85,6 +94,15 @@ export function sanitizeStyleValue(value: string): string {
 		cleaned = cleaned.replace(pattern, "");
 	}
 	return cleaned.trim();
+}
+
+export const CASE_SENSITIVE_ATTRIBUTES = new Map<string, string>([
+	["viewbox", "viewBox"],
+	["preserveaspectratio", "preserveAspectRatio"],
+]);
+
+export function canonicalAttributeName(lowerName: string): string {
+	return CASE_SENSITIVE_ATTRIBUTES.get(lowerName) ?? lowerName;
 }
 
 export function sanitizeStyleBlock(css: string): string {

--- a/tools/sanitize/test/sanitize.test.js
+++ b/tools/sanitize/test/sanitize.test.js
@@ -209,3 +209,77 @@ describe("JSML", () => {
 		assert.ok(!result.html.includes("onclick"));
 	});
 });
+
+describe("SVG support", () => {
+	it("preserves viewBox casing", () => {
+		const result = sanitizeHTML('<svg viewBox="0 0 100 100"></svg>');
+		assert.ok(result.includes("viewBox"));
+		assert.ok(!result.includes("viewbox"));
+	});
+
+	it("preserves preserveAspectRatio casing", () => {
+		const result = sanitizeHTML('<svg preserveAspectRatio="xMidYMid meet"></svg>');
+		assert.ok(result.includes("preserveAspectRatio"));
+		assert.ok(!result.includes("preserveaspectratio"));
+	});
+
+	it("preserves viewBox casing in JSML", async () => {
+		const { sanitizeJsml } = await import("../dist/jsml.js");
+		const result = sanitizeJsml([
+			["svg", { viewBox: "0 0 100 100" }, ["circle", { cx: "50", cy: "50", r: "40" }]],
+		]);
+		assert.ok(result.html.includes("viewBox"));
+		assert.ok(!result.html.includes("viewbox"));
+	});
+
+	it("strips foreignObject and its children", () => {
+		const result = sanitizeHTML('<svg><foreignObject><div>escape</div></foreignObject></svg>');
+		assert.ok(!result.includes("foreignObject"));
+		assert.ok(!result.includes("foreignobject"));
+		assert.ok(!result.includes("escape"));
+	});
+
+	it("strips animate from SVG", () => {
+		const result = sanitizeHTML('<svg><animate attributeName="x" /></svg>');
+		assert.ok(!result.includes("animate"));
+	});
+
+	it("strips set from SVG", () => {
+		const result = sanitizeHTML('<svg><set attributeName="fill" to="red" /></svg>');
+		assert.ok(!result.includes("<set"));
+	});
+});
+
+describe("interactive elements", () => {
+	it("preserves button with data-action", () => {
+		const result = sanitizeHTML('<button data-action="heal">Heal</button>');
+		assert.ok(result.includes("<button"));
+		assert.ok(result.includes("data-action"));
+	});
+
+	it("preserves progress with value and max", () => {
+		const result = sanitizeHTML('<progress value="70" max="100">70%</progress>');
+		assert.ok(result.includes("<progress"));
+		assert.ok(result.includes('value="70"'));
+		assert.ok(result.includes('max="100"'));
+	});
+
+	it("preserves meter with range attributes", () => {
+		const result = sanitizeHTML('<meter value="0.6" low="0.3" high="0.8" optimum="0.5">60%</meter>');
+		assert.ok(result.includes("<meter"));
+		assert.ok(result.includes('low="0.3"'));
+		assert.ok(result.includes('high="0.8"'));
+		assert.ok(result.includes('optimum="0.5"'));
+	});
+
+	it("preserves fieldset and legend", () => {
+		const result = sanitizeHTML("<fieldset><legend>Group</legend><input type=\"text\" /></fieldset>");
+		assert.ok(result.includes("<fieldset>"));
+		assert.ok(result.includes("<legend>"));
+	});
+
+	it("preserves details open attribute", () => {
+		const result = sanitizeHTML("<details open><summary>Info</summary></details>");
+		assert.ok(result.includes("<details open>") || result.includes('<details open="'));
+	});
+});

--- a/tools/typegen/package.json
+++ b/tools/typegen/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/typegen",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Generate TypeScript definitions from xript manifests.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/tools/validate/package.json
+++ b/tools/validate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xriptjs/validate",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Validate xript manifests against the specification schema.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/tools/wiz/Cargo.toml
+++ b/tools/wiz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xript-wiz"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Interactive TUI wizard for the xript toolchain — powered by xript fragments."
 license = "MIT"
@@ -14,8 +14,8 @@ name = "xript-wiz"
 path = "src/main.rs"
 
 [dependencies]
-xript-runtime = { version = "0.4.1", path = "../../runtimes/rust" }
-xript-ratatui = { version = "0.4.1", path = "../../renderers/ratatui" }
+xript-runtime = { version = "0.4.2", path = "../../runtimes/rust" }
+xript-ratatui = { version = "0.4.2", path = "../../renderers/ratatui" }
 ratatui = "0.29"
 ansi-to-tui = "7"
 crossterm = "0.28"


### PR DESCRIPTION
## Summary

- expanded the HTML sanitizer's allowed element list with `button`, `progress`, `meter`, `output`, `fieldset`, `legend`, and 14 SVG elements across all four implementations (TypeScript, Rust/ammonia, C#)
- added `foreignObject`, `animate`, `set` to stripped elements; added missing attributes (`open`, `low`/`high`/`optimum`, 18 SVG attributes); fixed `viewBox`/`preserveAspectRatio` casing
- fixed `js_value_to_json` in the Rust runtime — objects and arrays were silently returning `Null` due to a broken `JSON.stringify` call (#89)

## Test plan

- [x] `@xriptjs/sanitize` — 93 tests passing (was 71)
- [x] `@xriptjs/runtime` — 97 tests passing
- [x] `@xriptjs/runtime-node` — 97 tests passing
- [x] `xript-runtime` (Rust) — 48 tests passing (was 45)
- [x] `Xript.Runtime` (C#) — 116 tests passing
- [x] docs site builds clean