### PR TITLE
fix npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
-      - run: npm install -g npm@latest
       - run: npm ci
 
       - name: build sanitize


### PR DESCRIPTION
## Summary

- removed `npm install -g npm@latest` from the publish workflow — Node 22.22.2's bundled npm on the GitHub runner is broken (missing `promise-retry` module), so the self-upgrade step fails before anything else can run
- the npm bundled with `actions/setup-node@v4` is sufficient for OIDC provenance publishing

## Test plan

- [ ] re-trigger the npm publish workflow after merge to confirm v0.4.2 publishes successfully