### PR TITLE
publish workflow: Node 24 for OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - run: npm ci
 


### PR DESCRIPTION
## Summary

- bumped `node-version` from 22 to 24 in the npm publish workflow
- npm trusted publishing now requires npm CLI v11.5.1+; Node 22 ships with npm v10, which silently fails the OIDC handshake and returns a misleading E404 on every package
- Node 24 ships with npm v11+ which handles the handshake correctly
- this is why every v0.4.2 npm publish 404'd despite the workflow reporting success (`continue-on-error: true` swallowed the errors)

## Test plan

- [ ] re-trigger the npm publish workflow after merge to confirm v0.4.2 publishes