### PR TITLE
docs: refresh all package READMEs for v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Four runtimes, same manifest, same security model.
 | Rust | `xript-runtime` | QuickJS via rquickjs (native) | any Rust host (Tauri, CLI, servers) |
 | C# | `Xript.Runtime` | Jint (pure C# JS interpreter) | any .NET host (Unity, WPF, Blazor) |
 
-All four support host bindings, capability enforcement, hooks, resource limits, `loadMod()`, and fragment processing. The Rust runtime adds async host bindings (`Promise`/`await`) and `XriptHandle` for `Send + Sync` thread-safe ownership.
+All four support host bindings, capability enforcement, hooks, resource limits, `loadMod()`, and fragment processing. v0.5.0 brought a shared lifecycle pass to every runtime: cooperative cancellation (a host-driven `CancellationToken` distinct from timeouts), an opt-in per-capability audit channel, `ConsoleHandler` severity levels, sandbox hard caps (memory, CPU time, stack depth), ES module mods (`entry.format: "module"`) whose top-level named exports become host-invokable, provider-role resolution (`contributions.provides` + `resolve_role`), a runtime slot resolver (priority ordering, cardinality, capability enforcement), and a DAP-shaped debug protocol. The Rust runtime adds async host bindings (`Promise`/`await`) and `XriptHandle` for `Send + Sync` thread-safe ownership.
 
 ## Fragments
 
@@ -83,9 +83,11 @@ One CLI. Six subcommands.
 ```sh
 npx xript validate manifest.json           # validate app or mod manifests
 npx xript typegen manifest.json            # generate TypeScript .d.ts from a manifest
+npx xript typegen manifest.json --ambient  # emit an ambient .d.ts declaring the xript global
 npx xript docgen manifest.json -o docs/    # generate markdown API docs
 npx xript init                             # scaffold a new xript project (interactive)
 npx xript init --mod                       # scaffold a mod project
+npx xript init --mod --typescript          # scaffold an ESM TypeScript mod project
 npx xript sanitize fragment.html           # sanitize an HTML fragment
 npx xript scan src/ --manifest m.json      # scan @xript JSDoc tags into a manifest
 ```
@@ -160,14 +162,14 @@ xript/
 
 ## Project Status
 
-v0.4.1 -- 666 tests across 12 packages.
+v0.5.0 -- 1077 tests across 12 packages.
 
 | Area | Status |
 |------|--------|
-| Spec | v0.3: app manifests, mod manifests, slots, fragment protocol, capability model, security, annotations |
+| Spec | app manifests, mod manifests, slots, fragment protocol, capability model, security, annotations; v0.5.0 adds ES module mods, provider roles (`contributions.provides` + `resolve_role`), capability-grant data shapes, a DAP-shaped debug protocol, host-invoke exports, slot runtime semantics, manifest `extends`/deep-merge, and a mod-manifest `family` field |
 | Runtimes | 4 complete: JS/WASM, Node.js, Rust (async bindings, `XriptHandle`), C# |
 | Renderers | `xript-ratatui`: terminal fragment renderer for Ratatui apps |
-| Toolchain | unified `xript` CLI with validate, typegen, docgen, init, sanitize, scan; TUI wizard with audit and diff |
+| Toolchain | unified `xript` CLI with validate, typegen (`--ambient`), docgen, init (`--mod --typescript`), sanitize, scan; TUI wizard with audit and diff |
 | Publishing | 12 packages live: 8 npm (`@xriptjs/*`), 3 Rust crates (`crates.io`), 1 NuGet; OIDC trusted publishing with provenance |
 | Docs | 29-page site at xript.dev; interactive hero playground, Fragment Builder, Fragment Workbench |
 

--- a/renderers/ratatui/README.md
+++ b/renderers/ratatui/README.md
@@ -8,7 +8,7 @@ Fragment renderer for [xript](https://github.com/nekoyoubi/xript): turns `applic
 
 ```toml
 [dependencies]
-xript-ratatui = "0.3"
+xript-ratatui = "0.5"
 ```
 
 ## Usage

--- a/runtimes/csharp/README.md
+++ b/runtimes/csharp/README.md
@@ -63,6 +63,19 @@ var result = runtime.Execute("greet(\"World\")");
 - Mod loading via `LoadMod()` with cross-validation against the host manifest
 - No `eval`, no `Function`, no access to the host environment
 
+### v0.5.0
+
+- cooperative cancellation via a `CancellationToken` on `RuntimeOptions`; it interrupts in-flight execution and surfaces a distinct cancellation error (not a timeout), with Jint interrupting mid-run via its token
+- opt-in capability audit channel: a hook reporting every allowed host-binding invocation as `{ binding, capability, at }`
+- console severity: `ConsoleHandler` gained a severity enum (log/info/warn/error/debug) plus a trace channel
+- sandbox hard caps: host ceilings on memory, CPU time, and stack depth
+- manifest `extends` with deep-merge so a manifest can inherit and override host bindings; mod manifests gained an optional `family` field for grouping
+- host-invoke exports: mods declare named exports the host calls by name and whose return value it honors
+- ES module mods via `entry.format: "module"`, which evaluates the entry as a real ES module through Jint's module API; top-level named exports auto-register as host-invokable, and external imports stay denied
+- provider-role resolution: mods declare `contributions.provides` and the host calls `ResolveRole(role)` (first-installed-wins, settings-overridable) to bind a logical role to a concrete export
+- slot runtime resolver: ordering by priority, single/multiple cardinality, and capability enforcement on contributions
+- DAP-shaped debug protocol: set/clear breakpoints by source position, pause/resume/step in/over/out, and inspect scopes, locals, and stack frames (Jint pauses synchronously on the engine thread)
+
 ## API
 
 ### `XriptRuntime.Create(manifestJson, options?) -> XriptRuntime`
@@ -101,7 +114,7 @@ Releases sandbox resources. `XriptRuntime` implements `IDisposable`, so `using` 
 | Runs in browser | No | No | Yes | No |
 | Sandbox mechanism | Jint (pure C#) | QuickJS (native) | QuickJS WASM | Node.js `vm` module |
 | Best for | .NET apps, Unity, game engines | Rust apps, native tools | Cross-platform, browser, edge | Node.js servers, CLI tools |
-| Async bindings | Not yet | Not yet | Via asyncify WASM | Native `async`/`await` |
+| Async bindings | Not yet | Native (rquickjs) | Via asyncify WASM | Native `async`/`await` |
 
 Use this package when your host application is .NET. Use `xript-runtime` for Rust hosts. Use `@xriptjs/runtime` for JavaScript environments that need universal portability. Use `@xriptjs/runtime-node` for Node.js-only applications.
 

--- a/runtimes/js/README.md
+++ b/runtimes/js/README.md
@@ -45,6 +45,19 @@ runtime.dispose();
 - Supports capability-gated bindings, namespace bindings, hooks, and resource limits
 - No `eval`, no `Function`, no access to the host environment
 
+### v0.5.0
+
+- cooperative cancellation via a `CancellationToken` on the runtime options; it interrupts in-flight execution at the next check point and surfaces a distinct cancellation error (not a timeout), with QuickJS interrupting mid-run
+- opt-in capability audit channel: a hook reporting every allowed host-binding invocation as `{ binding, capability, at }`
+- console severity: log/info/warn/error/debug plus a trace channel
+- sandbox hard caps: host ceilings on memory, CPU time, and stack depth
+- manifest `extends` with deep-merge so a manifest can inherit and override host bindings; mod manifests gained an optional `family` field for grouping
+- host-invoke exports: mods declare named exports the host calls by name and whose return value it honors
+- ES module mods via `entry.format: "module"`, which evaluates the entry as a real ES module (requires the async sandbox from `initXriptAsync`); top-level named exports auto-register as host-invokable, and external imports stay denied
+- provider-role resolution: mods declare `contributions.provides` and the host calls `resolveRole(role)` (first-installed-wins, settings-overridable) to bind a logical role to a concrete export
+- slot runtime resolver: ordering by priority, single/multiple cardinality, and capability enforcement on contributions
+- DAP-shaped debug protocol: set/clear breakpoints by source position, pause/resume/step in/over/out, and inspect scopes, locals, and stack frames (requires the async sandbox)
+
 ## API
 
 ### `initXript(): Promise<XriptFactory>`
@@ -85,7 +98,7 @@ Frees the WASM sandbox resources.
 | Sandbox mechanism | QuickJS WASM | Node.js `vm` module | QuickJS (native) |
 | Zero dependencies on Node | Yes | Requires Node.js | Rust crate |
 | Performance | Good (WASM overhead) | Native V8 speed | Native QuickJS speed |
-| Async bindings | Via asyncify WASM | Native `async`/`await` | Not yet |
+| Async bindings | Via asyncify WASM | Native `async`/`await` | Native (rquickjs) |
 
 Use this package when you need **universal portability** (browser, edge, serverless). Use `@xriptjs/runtime-node` when you're Node.js-only and want native V8 performance. Use `xript-runtime` when your host application is written in Rust.
 

--- a/runtimes/node/README.md
+++ b/runtimes/node/README.md
@@ -54,6 +54,19 @@ const runtime = await createRuntimeFromFile("./manifest.json", {
 - Supports capability-gated bindings, namespace bindings, hooks, and resource limits
 - No `eval`, no `Function`, no dynamic code generation
 
+### v0.5.0
+
+- cooperative cancellation via a `CancellationToken` on the runtime options; it surfaces a distinct cancellation error (not a timeout), and since `vm` has no mid-run interrupt hook the token is checked at execute/invoke entry
+- opt-in capability audit channel: a hook reporting every allowed host-binding invocation as `{ binding, capability, at }`
+- console severity: log/info/warn/error/debug plus a trace channel
+- sandbox hard caps: host ceilings on memory, CPU time, and stack depth
+- manifest `extends` with deep-merge so a manifest can inherit and override host bindings; mod manifests gained an optional `family` field for grouping
+- host-invoke exports: mods declare named exports the host calls by name and whose return value it honors
+- ES module mods via `entry.format: "module"`, which evaluates the entry as a real ES module through `vm.SourceTextModule`; top-level named exports auto-register as host-invokable, and external imports stay denied
+- provider-role resolution: mods declare `contributions.provides` and the host calls `resolveRole(role)` (first-installed-wins, settings-overridable) to bind a logical role to a concrete export
+- slot runtime resolver: ordering by priority, single/multiple cardinality, and capability enforcement on contributions
+- DAP-shaped debug protocol: set/clear breakpoints by source position, pause/resume/step in/over/out, and inspect scopes, locals, and stack frames (AST instrumentation)
+
 ## API
 
 ### `createRuntime(manifest, options): XriptRuntime`

--- a/runtimes/rust/README.md
+++ b/runtimes/rust/README.md
@@ -48,8 +48,25 @@ let result = runtime.execute("greet(\"World\")")?;
 
 - Runs user-provided JavaScript inside a native QuickJS sandbox (via rquickjs)
 - Only functions declared in the manifest are available to scripts; everything else is blocked
-- Supports capability-gated bindings, namespace bindings, hooks, and resource limits
+- Supports capability-gated bindings, namespace bindings (sync and async), hooks, and resource limits
+- Async namespaces via a `namespace_builder` combinator, `add_mixed_namespace` for property values alongside callable functions, and recursion into nested namespace members
+- `XriptHandle`, a `Send`+`Sync` wrapper for driving a runtime across threads
 - No `eval`, no `Function`, no access to the host environment
+
+### v0.5.0
+
+- `data:` URI subtype gate: `sanitize_html` now keeps only `data:image/{png,jpeg,gif,svg+xml}` and strips the rest, closing a `data:text/html` XSS hole that any embedding host inherited
+- cooperative cancellation via a `CancellationToken` on `RuntimeOptions`; it interrupts in-flight execution at the next check point and surfaces a distinct cancellation error (not a timeout), with rquickjs interrupting mid-run
+- opt-in capability audit channel: a hook reporting every allowed host-binding invocation as `{ binding, capability, at }`
+- console severity: `ConsoleHandler` gained a severity enum (log/info/warn/error/debug) plus a trace channel
+- sandbox hard caps: host ceilings on memory, CPU time, and stack depth
+- manifest `extends` with deep-merge so a manifest can inherit and override host bindings; mod manifests gained an optional `family` field for grouping
+- host-invoke exports: mods declare named exports the host calls by name and whose return value it honors
+- ES module mods via `entry.format: "module"`, which evaluates the entry as a real ES module; top-level named exports auto-register as host-invokable, and external imports stay denied
+- provider-role resolution: mods declare `contributions.provides` and the host calls `resolve_role(role)` (first-installed-wins, settings-overridable) to bind a logical role to a concrete export
+- slot runtime resolver: ordering by priority, single/multiple cardinality, and capability enforcement on contributions
+- DAP-shaped debug protocol: set/clear breakpoints by source position, pause/resume/step in/over/out, and inspect scopes, locals, and stack frames (rquickjs 0.10 exposes no per-line hook, so fidelity is documented)
+- fixed async workflows swallowing uncaught throws; a rejected top-level promise now surfaces the real rejection instead of reading as a successful `undefined`
 
 ## API
 
@@ -80,7 +97,7 @@ Returns a reference to the parsed manifest.
 | Language | Rust | JavaScript/TypeScript | JavaScript/TypeScript |
 | Runs in browser | No | Yes | No |
 | Sandbox mechanism | QuickJS (native) | QuickJS WASM | Node.js `vm` module |
-| Async bindings | Not yet | Via asyncify WASM | Native `async`/`await` |
+| Async bindings | Native (`namespace_builder`) | Via asyncify WASM | Native `async`/`await` |
 | Best for | Rust apps, game engines, native tools | Cross-platform, browser, edge | Node.js servers, CLI tools |
 
 Use this crate when your host application is written in Rust. Use `@xriptjs/runtime` for JavaScript environments that need universal portability. Use `@xriptjs/runtime-node` for Node.js-only applications.

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -34,6 +34,7 @@ Generate TypeScript definitions from a manifest.
 ```sh
 xript typegen manifest.json              # stdout
 xript typegen manifest.json -o types.d.ts  # file
+xript typegen mod.json --ambient         # ambient .d.ts for mod authoring
 ```
 
 ### `xript docgen <manifest.json>`
@@ -50,9 +51,10 @@ xript docgen manifest.json -o docs/ --link-format "[{name}]({url})"
 Scaffold a new xript app or mod project.
 
 ```sh
-xript init my-app          # interactive
-xript init my-app --yes    # defaults, no prompts
-xript init my-mod --mod    # mod project
+xript init my-app              # interactive
+xript init my-app --yes        # defaults, no prompts
+xript init my-mod --mod        # mod project
+xript init my-mod --mod --typescript  # ESM TypeScript mod
 ```
 
 ### `xript sanitize <file.html>`

--- a/tools/docgen/README.md
+++ b/tools/docgen/README.md
@@ -53,10 +53,11 @@ Reads a manifest JSON file and generates markdown documentation.
 ## What it generates
 
 - Binding reference with function signatures and parameter tables
-- Namespace binding documentation with member listings
+- Namespace binding documentation with member listings, including nested namespaces
 - Capability reference with risk levels
 - Hook documentation with handler signatures and phase listings
-- Custom type documentation with field tables
+- Custom type documentation with field tables, including record-type fields
+- Provider-role documentation for mod contributions
 - Usage examples (when provided in the manifest)
 
 ## Documentation

--- a/tools/init/README.md
+++ b/tools/init/README.md
@@ -39,6 +39,15 @@ npx @xriptjs/init my-mod --yes
 
 Uses defaults: tier 2, TypeScript.
 
+### Mods
+
+```sh
+npx @xriptjs/init my-mod --mod                # mod project
+npx @xriptjs/init my-mod --mod --typescript   # ESM TypeScript mod
+```
+
+`--mod --typescript` scaffolds an ESM TypeScript mod: an ESM `tsconfig`, an `export`-based example entry, and ambient types wired in for real intellisense.
+
 ### Options
 
 ```
@@ -46,7 +55,8 @@ npx @xriptjs/init [directory] [options]
 
 Options:
   --yes, -y          Skip prompts, use defaults
-  --tier <2|3>       Adoption tier (2 = bindings, 3 = full scripting)
+  --mod              Generate a mod project instead of an app
+  --tier <2|3|4>     Adoption tier (2 = bindings, 3 = advanced scripting, 4 = full feature)
   --typescript       Generate TypeScript output (default)
   --javascript       Generate JavaScript output
   --help, -h         Show help

--- a/tools/typegen/README.md
+++ b/tools/typegen/README.md
@@ -15,9 +15,20 @@ npm install @xriptjs/typegen
 ```sh
 npx xript-typegen manifest.json              # print to stdout
 npx xript-typegen manifest.json -o types.d.ts  # write to file
+npx xript-typegen mod.json --ambient         # ambient .d.ts for mod authoring
 ```
 
 Generates `.d.ts` files with full JSDoc, namespace support, and hook type definitions from a manifest.
+
+### Options
+
+```
+--output, -o            Output file path (default: stdout)
+--ambient               Emit an ambient .d.ts declaring the in-sandbox xript surface for mod authors
+--include-grant-shapes  Emit CapabilityPrompt, InstallDescriptor, DiscoveryResult interfaces
+```
+
+`--ambient` declares the `xript` global a mod sees at runtime: host bindings, `exports.register`, and the mod's own declared exports and types. TypeScript mod authors get real intellisense and typecheck.
 
 ## API
 
@@ -58,6 +69,9 @@ Reads a manifest JSON file and generates TypeScript declarations.
 - `interface` for custom types with fields
 - `type` aliases for enum types
 - `declare namespace hooks` with handler signatures and phased hook namespaces
+- `ProvidedRoles` types for provider-role contributions
+- typed accessors for record-type fields (with `default` and inline `enum` support)
+- optional capability-grant shape interfaces via `--include-grant-shapes`
 - JSDoc with `@param`, `@deprecated`, and `@remarks` annotations
 
 ## Documentation

--- a/tools/validate/README.md
+++ b/tools/validate/README.md
@@ -27,6 +27,16 @@ Validates one or more manifest files and prints results:
 
 Exit code is `1` if any file fails validation.
 
+## What it validates
+
+- app and mod manifests against the xript JSON Schema (with auto-detection)
+- cross-validation between an app manifest and a mod manifest
+- manifest `extends` with deep-merge (a manifest inheriting and overriding host bindings)
+- the mod-manifest `family` field for addon grouping
+- ES-module `entry.format`, including a static-import lint (external imports are denied at load)
+- a CommonJS guardrail: `require(`, `module.exports`, and top-level `exports.` in a mod entry fail loudly with a fix-it message
+- provider-role contributions (`contributions.provides`), flagging duplicate roles and unbound functions
+
 ## API
 
 ```javascript


### PR DESCRIPTION
Brings every published package's README current with v0.5.0 before the release publishes them to npm / crates.io / NuGet.

- **Top-level README**: Project Status bumped to v0.5.0 (1077 tests across 12 packages); spec row lists the new surfaces; runtimes capability line and toolchain flags updated.
- **Runtime READMEs** (`@xriptjs/runtime`, `@xriptjs/runtime-node`, `xript-runtime`, `Xript.Runtime`): added v0.5.0 capability blocks — cancellation, capability audit channel, console severity, sandbox hard caps, manifest `extends` + `family`, host-invoke exports, ES module mods, provider-role resolution, slot resolver, and the DAP-shaped debug protocol — with per-runtime specifics.
- **Tool READMEs**: documented `typegen --ambient`, `init --mod --typescript`, the new validate checks, and provider-role/record docgen output.
- **Fix**: the JS and C# comparison tables wrongly listed Rust async bindings as "Not yet" — corrected.
- `xript-ratatui` install-snippet version pin bumped; `@xriptjs/sanitize` and `xript-wiz` needed no change.

Docs-only; no code, schema, or version changes.