### PR TITLE
fix v0.6.0 publish failures (npm ordering + wiz compile)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -13,11 +13,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: publish xript-runtime
+        continue-on-error: true
         run: cargo publish --allow-dirty --manifest-path runtimes/rust/Cargo.toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
       - name: publish xript-ratatui
+        continue-on-error: true
         run: cargo publish --allow-dirty --manifest-path renderers/ratatui/Cargo.toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
@@ -26,6 +28,7 @@ jobs:
         run: sleep 60
 
       - name: publish xript-wiz
+        continue-on-error: true
         run: cargo publish --allow-dirty --manifest-path tools/wiz/Cargo.toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,12 +30,12 @@ jobs:
         run: npm run build --workspace=tools/docgen
       - name: build init
         run: npm run build --workspace=tools/init
-      - name: build cli
-        run: npm run build --workspace=tools/cli
       - name: build runtime
         run: npm run build --workspace=runtimes/js
       - name: build runtime-node
         run: npm run build --workspace=runtimes/node
+      - name: build cli
+        run: npm run build --workspace=tools/cli
 
       - name: test sanitize
         run: npm test --workspace=tools/sanitize

--- a/tools/wiz/src/screens/validate.rs
+++ b/tools/wiz/src/screens/validate.rs
@@ -222,6 +222,7 @@ fn validate_app_manifest(content: &str) -> serde_json::Value {
             host_bindings: xript_runtime::HostBindings::new(),
             capabilities: vec![],
             console: xript_runtime::ConsoleHandler::default(),
+            ..Default::default()
         },
     ) {
         Ok(_rt) => {


### PR DESCRIPTION
## v0.6.0 publish hotfix

The v0.6.0 release tag fired the publish workflows; NuGet succeeded, but **npm** and **crates.io** both failed on issues the local check path doesn't exercise. Three fixes:

- **npm build ordering** (`.github/workflows/publish.yml`) — the new `xript run` command's `run.ts` imports `@xriptjs/runtime`, but `build cli` ran before `build runtime`, so `tsc` failed with `TS2307: Cannot find module '@xriptjs/runtime'`. Runtime/runtime-node now build before cli. (Nothing reached npm — the job died before any publish step.)
- **`xript-wiz` compile** (`tools/wiz/src/screens/validate.rs`) — `RuntimeOptions` grew `cancellation`, `audit`, `hard_limits`, `role_preferences`, and `debug` in v0.6.0; the wiz `RuntimeOptions` literal only set three fields. `cargo publish --verify` was the first build to compile wiz, so it caught what local checks (which don't build `tools/wiz`) missed. Added `..Default::default()`.
- **crates re-run resilience** (`.github/workflows/publish-crates.yml`) — `xript-runtime@0.6.0` and `xript-ratatui@0.6.0` published successfully before wiz failed, so a plain re-run would die trying to re-publish them. Added `continue-on-error: true` to the publish steps (matching `publish.yml`) so a re-run skips the already-published crates and reaches `xript-wiz`.

### Verification

- `xript-wiz` builds clean against the workspace runtime
- `runtimes/js` → `tools/cli` build in the corrected order, import resolves
- `continue-on-error` is a config change

After merge: re-trigger the npm and crates publish workflows from `main`.
