### PR TITLE
documented two v0.7 adoption edges

### DIFF
--- a/docs/src/content/docs/tools/score.md
+++ b/docs/src/content/docs/tools/score.md
@@ -53,6 +53,8 @@ A slot or capability marked `reserved: true` is aspirational: surface declared a
 
 ## What it does not measure
 
+The gauge is also **scoped to the one manifest you hand it**. A host that splits its surface across trust boundaries (an addon-contract manifest and a separate fragment-surface manifest, say) should score each manifest on its own terms; a library exposed only on the fragment surface will not, and should not, register on the addon contract's capacity. Don't pad a manifest with surface nothing on that contract uses just to move the number.
+
 `score` cannot tell whether a binding or hook is *called from inside a mod's script*; that lives in the script, not the manifest. And it cannot tell whether the host/mod boundary is *drawn correctly*: it can confirm the surface is exposed and the contract holds, but it cannot read intent. A 100 means all five surfaces are open and the contract holds, not that the design is right. Use the score as a floor and a litmus; use [`xript lint`](/tools/lint/) for the actionable list of dead slots and vestigial capabilities behind the number, and the [host/mod boundary](/guidance/boundary/) doctrine for the judgment neither tool can make.
 
 ## Gating in CI

--- a/spec/modules.md
+++ b/spec/modules.md
@@ -82,6 +82,10 @@ export function render(md) { return renderMarkdown(md); }
 - **CommonJS guard applies:** registered library source is subject to the same `CommonJSDetectedError` detector as mod entries.
 - **Capability declaration integrity:** a library's `capability` scope must be declared in the manifest's `capabilities` map, the same rule that governs binding and slot gates.
 
+### Runtime requirements
+
+Libraries link at module-entry evaluation, so they ride the module path end to end. In the universal JS runtime that means the **async sandbox**: `initXriptAsync` + `loadModAsync`. The sync sandbox rejects module-format entries outright (`ModuleUnsupportedError`), and there is no other import site — a host on the sync path adopts the async runtime first, then adds `libraries`. The Node, Rust, and C# runtimes evaluate modules on their standard load paths, so no equivalent split exists there.
+
 ### What stays host-side
 
 The library lift is for **pure compute** — markdown rendering, date math, validation, formatting: code that needs no privilege beyond the sandbox. Anything touching host state, the filesystem, or the network stays a **host binding** (host-side execution, JSON boundary, per-function capability). The two columns are complementary, not competing; a host typically offers both.


### PR DESCRIPTION
First-adopter feedback from v0.7.0, both doc-shaped:

- **Approved libraries require the module path.** spec/modules.md now says so plainly: libraries link at module-entry evaluation, so the universal JS runtime needs `initXriptAsync` + `loadModAsync` (the sync sandbox rejects module-format entries outright), while the Node, Rust, and C# runtimes evaluate modules on their standard load paths. A host on the sync path adopts the async runtime first, then adds `libraries`.
- **The score gauge is scoped to the manifest it's handed.** The score docs now state that hosts splitting surface across trust boundaries (separate addon-contract and fragment-surface manifests) should score each manifest on its own terms — and not pad a contract with surface nothing on it uses just to move the number.

## Test plan

- [ ] `npm run docs:build` clean